### PR TITLE
feat:新增自动获取设置的URL地址

### DIFF
--- a/custom_components/xiaomi_home/config_flow.py
+++ b/custom_components/xiaomi_home/config_flow.py
@@ -170,6 +170,10 @@ class XiaomiMihomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         self.hass.data.setdefault(DOMAIN, {})
         loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        if self.hass.config.external_url:
+            global OAUTH_REDIRECT_URL 
+            _LOGGER.info(f"check OAUTH_REDIRECT_URL: {self.hass.config.external_url}")
+            OAUTH_REDIRECT_URL = self.hass.config.external_url
 
         if self._virtual_did is None:
             self._virtual_did = str(secrets.randbits(64))


### PR DESCRIPTION
新增自动获取设置的URL地址
以解决 OAuth2 认证跳转地址建议修改为 homeassistant局域网ip， homeassistant.local无法访问

issuse: #8 

![5ad672197d7aa178e027e50f7ab045c9](https://github.com/user-attachments/assets/f41514c8-e74f-4e2e-8c65-b3691e688801)
![ecf17eeaa2254f852e88357125cdb887](https://github.com/user-attachments/assets/2de725f6-a5ea-469c-b365-1031515e2c75)

### **重要：需要iot平台进行白名单评估 因为iot平台的oath2存在回调白名单**

![192fc320f270b22a544c29a18ba30f48](https://github.com/user-attachments/assets/808069da-e258-47af-bd4e-77061d5716a5)
![90dc1220711a971737c5d91f638cd98d](https://github.com/user-attachments/assets/7850033f-1cb7-43eb-91b8-c3dbbbba7154)

