### PR TITLE
[FEAT] add issue/discussion auto translate CI

### DIFF
--- a/.github/workflows/translator.yml
+++ b/.github/workflows/translator.yml
@@ -1,0 +1,30 @@
+name: 'issue and discussion translator'
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  translate:
+    permissions:
+      issues: write
+      discussions: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lizheming/github-translate-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          IS_MODIFY_TITLE: true
+          APPEND_TRANSLATION: true


### PR DESCRIPTION
This is a workflow that help project translations and appends the translations to the original comments automatically when recognizes non-English content posted. The process is automated and does not disturb users.

Currently, there are a lot of Chinese feedback content in our project. I hope to add this CI automation process to help facilitate international communication of the project.

If you want to look effect cases, please refer to the following test issue:

https://github.com/lizheming/ha_xiaomi_home/issues/1

and also my other project has some real case can visit: 

https://github.com/walinejs/waline/issues