### PR TITLE
fix: directory copy issue

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,13 @@ rm -rf "$config_path/custom_components/xiaomi_home"
 script_path=$(dirname "$0")
 # Change to the script path.
 cd "$script_path"
+
 # Copy the new version.
-cp -r custom_components/xiaomi_home/  "$config_path/custom_components/"
+if [ -d "$config_path/custom_components" ]; then
+    cp -r custom_components/xiaomi_home/  "$config_path/custom_components/"
+else
+    cp -r custom_components/  "$config_path/custom_components/"
+fi
 
 # Done.
 echo "Xiaomi Home installation is completed. Please restart Home Assistant."


### PR DESCRIPTION
When the first time to install home assistant and ssh to it, there is no "/config/custom_components/" directory in the homeassistant docker. At this time, if the user runs the install.sh, there will not create a "xiaomi_home" directory in the "/config/custom_components/" path. Instead, the file structure will be like below:
```
.
├── custom_components
│   ├── __init__.py
│   ├── binary_sensor.py
│   ├── button.py
│   ├── climate.py
│   ├── config_flow.py
│   ├── cover.py
│   ├── event.py
│   ├── fan.py
│   ├── humidifier.py
│   ├── light.py
│   ├── manifest.json
│   ├── miot
│   ├── notify.py
│   ├── number.py
│   ├── select.py
│   ├── sensor.py
│   ├── switch.py
│   ├── text.py
│   ├── translations
│   ├── vacuum.py
│   └── water_heater.py
```
And if user wants to search the Xiaomi Home in the home assistant "ADD INTEGRATION" page, there will be no result.
So I add a "if" statement in the install.sh. It can fix the issue. If there is a better method, we can communicate.