### PR TITLE
fix: use binary sensor class for door and windows sensor and water leak sensor

### DIFF
--- a/custom_components/xiaomi_home/binary_sensor.py
+++ b/custom_components/xiaomi_home/binary_sensor.py
@@ -88,4 +88,7 @@ class BinarySensor(MIoTPropertyEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """On/Off state. True if the binary sensor is on, False otherwise."""
+        """If it is a door and windows sensor, revert the value."""            
+        if self._attr_device_class == 'door':                                   
+            return not (self._value is True) 
         return self._value is True

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -47,6 +47,7 @@ Conversion rules of MIoT-Spec-V2 instance to Home Assistant entity.
 """
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.event import EventDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass     
 
 # pylint: disable=pointless-string-statement
 """SPEC_DEVICE_TRANS_MAP
@@ -390,6 +391,14 @@ SPEC_PROP_TRANS_MAP: dict[str, dict | str] = {
         'no-one-determine-time': {
             'device_class': SensorDeviceClass.DURATION,
             'entity': 'sensor'
+        },
+        'submersion-state': {                                                 
+            'device_class': BinarySensorDeviceClass.MOISTURE,                  
+            'entity': 'binary_sensor'                                           
+        },                                                                     
+        'contact-state': {                                                      
+            'device_class': BinarySensorDeviceClass.DOOR,                     
+            'entity': 'binary_sensor'                                          
         },
         'has-someone-duration': 'no-one-determine-time',
         'no-one-duration': 'no-one-determine-time'


### PR DESCRIPTION
fix: use binary sensor class for door and windows sensor and water leak sensor

The original version uses `sensor` class for various sensors, such as door and windows sensors, water leak sensors, occupancy sensors, motion sensors, etc., which prevents the HomeKit Bridge from generating corresponding entities.
Commit https://github.com/micturkey/ha_xiaomi_home/commit/162f943924f89c564dc4e0ebb477e6a7a9b00225 is to use `binary sensor` class for door and windows sensor and water leak sensor.
Another commit https://github.com/micturkey/ha_xiaomi_home/commit/9cc2c52d441ba2751fc784c29b4ea941f5f345af is to solve this issue: `binary sensor` class for Door sensor in Home Assistant uses true to indicate open, which is opposite of Xiaomi Home. This commit reverts the value of door and windows sensor to make them the same.

Other sensors, like occupancy sensors and motion sensors, however, still need to be fixed with `binary sensor` class.

Correspoding issue: https://github.com/XiaoMi/ha_xiaomi_home/issues/206