### PR TITLE
fix: use binary sensor to implement read-only bool property

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -560,7 +560,10 @@ class MIoTDevice:
                             # Irregular property will not be transformed.
                             pass
                     elif prop.readable or prop.notifiable:
-                        prop.platform = 'sensor'
+                        if prop.format_ == 'bool':
+                            prop.platform = 'binary_sensor'
+                        else:
+                            prop.platform = 'sensor'
                 if prop.platform:
                     self.append_prop(prop=prop)
             # STEP 3.2: event conversion


### PR DESCRIPTION
这个 PR 会导致只读的布尔类型的属性`sensor`实体不可用，并使用`binary_sensor`生成新的实体。