### PR TITLE
misc: remove duplicate dependency

### DIFF
--- a/custom_components/xiaomi_home/manifest.json
+++ b/custom_components/xiaomi_home/manifest.json
@@ -23,8 +23,7 @@
         "paho-mqtt<=2.0.0",
         "numpy",
         "cryptography",
-        "psutil",
-        "aiohttp[speedups]"
+        "psutil"
     ],
     "version": "v0.1.4b0",
     "zeroconf": [


### PR DESCRIPTION
## Why is this change made
Per knoop7's suggestion. Removing dependency on aiohttp. aiohttp is a dependency of the home assistant core. So this should not break anything.
Resolving https://github.com/XiaoMi/ha_xiaomi_home/issues/308