### PR TITLE
fix: fix unit convert attribute error

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -628,7 +628,7 @@ class MIoTDevice:
             # pylint: disable=import-outside-toplevel
             from homeassistant.const import UnitOfConductivity
             unit_map['μS/cm'] = UnitOfConductivity.MICROSIEMENS_PER_CM
-        except ImportError:
+        except Exception:  # pylint: disable=broad-except
             unit_map['μS/cm'] = 'μS/cm'
 
         return unit_map.get(spec_unit, None)


### PR DESCRIPTION
### Fixed
- fix unit_convert AttributeError, Change to catch all Exception.

Error log:
AttributeError: type object 'UnitOfConductivity' has no attribute 'MICROSIEMENS_PER_CM'