### PR TITLE
fix: lumi.switch.acn040 identify service translation of zh-Hans

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -156,6 +156,13 @@
         }
     },
     "urn:miot-spec-v2:device:switch:0000A003:lumi-acn040:1": {
+        "en": {
+            "service:011": "Right Button On and Off",
+            "service:011:property:001": "Right Button On and Off",
+            "service:015:action:001": "Left Button Identify",
+            "service:016:action:001": "Middle Button Identify",
+            "service:017:action:001": "Right Button Identify"
+        },
         "zh-Hans": {
             "service:015:action:001": "左键确认",
             "service:016:action:001": "中键确认",

--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -154,5 +154,15 @@
             "service:004:event:001": "虛擬事件發生",
             "service:004:property:001": "事件名稱"
         }
+    },
+    "urn:miot-spec-v2:device:switch:0000A003:lumi-acn040:1": {
+        "zh-Hans": {
+            "service:015": "设备确认",
+            "service:015:action:001": "左键确认",
+            "service:016": "设备确认",
+            "service:016:action:001": "中键确认",
+            "service:017": "设备确认",
+            "service:017:action:001": "右键确认"
+        }
     }
 }

--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -157,11 +157,8 @@
     },
     "urn:miot-spec-v2:device:switch:0000A003:lumi-acn040:1": {
         "zh-Hans": {
-            "service:015": "设备确认",
             "service:015:action:001": "左键确认",
-            "service:016": "设备确认",
             "service:016:action:001": "中键确认",
-            "service:017": "设备确认",
             "service:017:action:001": "右键确认"
         }
     }


### PR DESCRIPTION
To solve confusing action name in #254 