### PR TITLE
feat: support manual input of oauth2 redirect url

### DIFF
--- a/custom_components/xiaomi_home/translations/zh-Hans.json
+++ b/custom_components/xiaomi_home/translations/zh-Hans.json
@@ -16,6 +16,7 @@
                     "cloud_server": "登录地区",
                     "integration_language": "语言",
                     "oauth_redirect_url": "认证跳转地址",
+                    "use_manual_oauth_redirect_url_after_redirect": "认证后手动输入跳转地址",
                     "network_detect_config": "集成网络配置"
                 }
             },
@@ -25,6 +26,13 @@
                 "data": {
                     "network_detect_addr": "网络检测地址",
                     "check_network_deps": "检测网络依赖项"
+                }
+            },
+            "oauth_manual": {
+                "title": "输入跳转地址",
+                "description": "### [请点击此处进行登录]({link})，然后将重定向的链接复制到下面",
+                "data": {
+                    "oauth_redirect_url": "认证跳转地址"
                 }
             },
             "oauth_error": {


### PR DESCRIPTION
To solve #480 #8 #126 
User can now manually enter oauth2 redirect url after logging in.

![image](https://github.com/user-attachments/assets/0a78feca-83a5-43ed-8d53-68de0af6ecc9)
![image](https://github.com/user-attachments/assets/401c8179-acd0-48ff-b2bb-35b02d52e1dc)
