### PR TITLE
feat: limit *light.mode count (value-range)

### DIFF
--- a/custom_components/xiaomi_home/light.py
+++ b/custom_components/xiaomi_home/light.py
@@ -188,7 +188,7 @@ class Light(MIoTServiceEntity, LightEntity):
                         > self._VALUE_RANGE_MODE_COUNT_MAX
                     ):
                         _LOGGER.error(
-                            'Too many mode values, %s, %s, %s',
+                            'too many mode values, %s, %s, %s',
                             self.entity_id, prop.name, prop.value_range)
                     else:
                         for value in range(
@@ -201,9 +201,6 @@ class Light(MIoTServiceEntity, LightEntity):
                     self._attr_effect_list = list(self._mode_list.values())
                     self._attr_supported_features |= LightEntityFeature.EFFECT
                     self._prop_mode = prop
-                else:
-                    _LOGGER.error('invalid mode format, %s', self.entity_id)
-                    continue
 
         if not self._attr_supported_color_modes:
             if self._prop_brightness:

--- a/custom_components/xiaomi_home/light.py
+++ b/custom_components/xiaomi_home/light.py
@@ -180,20 +180,22 @@ class Light(MIoTServiceEntity, LightEntity):
                         for item in prop.value_list}
                 elif isinstance(prop.value_range, dict):
                     mode_list = {}
-                    if (int((
-                        prop.value_range['value-range'][1]
-                        - prop.value_range['value-range'][0]
-                    ) / prop.value_range['value-range'][2])
+                    if (
+                        int((
+                            prop.value_range['max']
+                            - prop.value_range['min']
+                        ) / prop.value_range['step'])
                         > self._VALUE_RANGE_MODE_COUNT_MAX
                     ):
                         _LOGGER.error(
                             'Too many mode values, %s, %s, %s',
                             self.entity_id, prop.name, prop.value_range)
-                        continue
-                    for value in range(
-                            prop.value_range['min'], prop.value_range['max'],
-                            prop.value_range['step']):
-                        mode_list[value] = f'mode {value}'
+                    else:
+                        for value in range(
+                                prop.value_range['min'],
+                                prop.value_range['max'],
+                                prop.value_range['step']):
+                            mode_list[value] = f'mode {value}'
                 if mode_list:
                     self._mode_list = mode_list
                     self._attr_effect_list = list(self._mode_list.values())

--- a/custom_components/xiaomi_home/light.py
+++ b/custom_components/xiaomi_home/light.py
@@ -148,13 +148,13 @@ class Light(MIoTServiceEntity, LightEntity):
                     self._attr_supported_features |= LightEntityFeature.EFFECT
                     self._prop_mode = prop
                 else:
-                    _LOGGER.error(
+                    _LOGGER.info(
                         'invalid brightness format, %s', self.entity_id)
                     continue
             # color-temperature
             if prop.name == 'color-temperature':
                 if not isinstance(prop.value_range, dict):
-                    _LOGGER.error(
+                    _LOGGER.info(
                         'invalid color-temperature value_range format, %s',
                         self.entity_id)
                     continue
@@ -187,7 +187,7 @@ class Light(MIoTServiceEntity, LightEntity):
                         ) / prop.value_range['step'])
                         > self._VALUE_RANGE_MODE_COUNT_MAX
                     ):
-                        _LOGGER.error(
+                        _LOGGER.info(
                             'too many mode values, %s, %s, %s',
                             self.entity_id, prop.name, prop.value_range)
                     else:
@@ -201,6 +201,9 @@ class Light(MIoTServiceEntity, LightEntity):
                     self._attr_effect_list = list(self._mode_list.values())
                     self._attr_supported_features |= LightEntityFeature.EFFECT
                     self._prop_mode = prop
+                else:
+                    _LOGGER.info('invalid mode format, %s', self.entity_id)
+                    continue
 
         if not self._attr_supported_color_modes:
             if self._prop_brightness:

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.json
@@ -59,10 +59,5 @@
             "1",
             "5"
         ]
-    },
-    "urn:miot-spec-v2:device:switch:0000A003:lemesh-sw3f13": {
-        "properties": [
-            "11.3"
-        ]
     }
 }

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.json
@@ -59,5 +59,10 @@
             "1",
             "5"
         ]
+    },
+    "urn:miot-spec-v2:device:switch:0000A003:lemesh-sw3f13": {
+        "properties": [
+            "11.3"
+        ]
     }
 }


### PR DESCRIPTION
### Why？
In the [spec](https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:switch:0000A003:lemesh-sw3f13:1:0000C810) definition of `lemesh.switch.sw3f13`, the mode of indicator-light is defined as the value-range of 0 to 4294967295(possibly used for setting the do-not-disturb mode of the indicator light and the do-not-disturb time period.
), which leads to 4294967295 modes being generated during the re-conversion process, thereby causing an exception.

```json
{
    "iid": 3,
    "type": "urn:miot-spec-v2:property:mode:00000008:lemesh-sw3f13:1",
    "description": "Mode",
    "format": "uint32",
    // ...
    "value-range": [
        0,
        4294967295,
        1
    ],
    // ...
}
```
---

### Fixed

Restrict the number of modes according to the mode definition of all light types on the line.
Statistics of all the values of light.mode that are 'value-range' currently online, and their distribution is as follows, so limit the number of its modes to 30 to avoid excessive number of modes leading to memory leakage.

```json
// key='value-range' mode count
// value= product count
{
    "3": 1,
    "4": 32,
    "5": 5,
    "6": 23,
    "7": 1,
    "8": 3,
    "12": 2,
    "17": 1,
    "20": 1,
    "255": 1,
    "295": 1,
    "2147483647": 2,
    "4294967295": 51
}
```

