### PR TITLE
fix: update miot cloud raise error msg

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_cloud.py
+++ b/custom_components/xiaomi_home/miot/miot_cloud.py
@@ -166,7 +166,7 @@ class MIoTOauthClient:
                 key in res_obj['result']
                 for key in ['access_token', 'refresh_token', 'expires_in'])
         ):
-            raise MIoTOauthError(f'invalid http response, {http_res.text}')
+            raise MIoTOauthError(f'invalid http response, {res_str}')
 
         return {
             **res_obj['result'],


### PR DESCRIPTION
### Fixed
- When refreshing the token fails, it is able to print out the message content returned by the cloud.
