### PR TITLE
feat: filter miwifi.* devices

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_cloud.py
+++ b/custom_components/xiaomi_home/miot/miot_cloud.py
@@ -531,17 +531,18 @@ class MIoTHttpClient:
             name = device.get('name', None)
             urn = device.get('spec_type', None)
             model = device.get('model', None)
-            if did is None or name is None or urn is None or model is None:
-                _LOGGER.error(
-                    'get_device_list, cloud, invalid device, %s', device)
+            if did is None or name is None:
+                _LOGGER.info(
+                    'invalid device, cloud, %s', device)
+                continue
+            if urn is None or model is None:
+                _LOGGER.info(
+                    'missing the urn|model field, cloud, %s', device)
                 continue
             if did.startswith('miwifi.'):
-                # All devices with did starting with "miwifi." are routers
-                # that interface between the Xiaomi home cloud and the Xiaomi
-                # router cloud. These routers have all defined functions but
-                # have not been implemented, so they are all filtered out; some
-                # routers that are not "miwifi.*" also have this problem.
-                _LOGGER.info('ignore miwifi.* device, %s', did)
+                # The miwifi.* routers defined SPEC functions, but none of them
+                # were implemented.
+                _LOGGER.info('ignore miwifi.* device, cloud, %s', did)
                 continue
             device_infos[did] = {
                 'did': did,
@@ -642,7 +643,7 @@ class MIoTHttpClient:
         for did in dids:
             if did not in results:
                 devices.pop(did, None)
-                _LOGGER.error('get device info failed, %s', did)
+                _LOGGER.info('get device info failed, %s', did)
                 continue
             devices[did].update(results[did])
             # Whether sub devices

--- a/custom_components/xiaomi_home/miot/miot_cloud.py
+++ b/custom_components/xiaomi_home/miot/miot_cloud.py
@@ -535,6 +535,14 @@ class MIoTHttpClient:
                 _LOGGER.error(
                     'get_device_list, cloud, invalid device, %s', device)
                 continue
+            if did.startswith('miwifi.'):
+                # All devices with did starting with "miwifi." are routers
+                # that interface between the Xiaomi home cloud and the Xiaomi
+                # router cloud. These routers have all defined functions but
+                # have not been implemented, so they are all filtered out; some
+                # routers that are not "miwifi.*" also have this problem.
+                _LOGGER.info('ignore miwifi.* device, %s', did)
+                continue
             device_infos[did] = {
                 'did': did,
                 'uid': device.get('uid', None),

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.json
@@ -59,5 +59,10 @@
             "1",
             "5"
         ]
+    },
+    "urn:miot-spec-v2:device:router:0000A036:xiaomi-rd03": {
+        "services": [
+            "*"
+        ]
     }
 }


### PR DESCRIPTION
### Why?
All devices with did starting with "miwifi." are routers that interface between the Xiaomi home cloud and the Xiaomi router cloud. These routers have all defined functions but have not been implemented, so they are all filtered out; some routers that are not "miwifi.*" also have this problem.

### Changed
Filter the devices whose did starts with "miwifi".

**After the update, it is necessary to enter the integrated instance: Configuration > Update Device Information, and delete the unavailable devices.**
