### PR TITLE
feat: add climate support for electric blanket

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -241,6 +241,29 @@ SPEC_DEVICE_TRANS_MAP: dict[str, dict | str] = {
             },
         },
         'entity': 'heater'
+    },
+    'electric-blanket': {
+        'required': {
+            'electric-blanket': {
+                'required': {
+                    'properties': {
+                        'on': {'read', 'write'}
+                    }
+                },
+                'optional': {
+                    'properties': {'target-temperature'}
+                },
+            }
+        },
+        'optional': {
+            'environment': {
+                'required': {},
+                'optional': {
+                    'properties': {'temperature'}
+                }
+            },
+        },
+        'entity': 'heater'
     }
 }
 


### PR DESCRIPTION
Enable the climate feature (control panel, HomeKit Bridge accessory, etc.) for `electric-blanket` devices.

Since the `class Heater` matches the properties of `electric-blanket` (`on`, `target-temperature` and `temperature`), we simply add a device conversion for `electric-blanket`, and map them to `heater` entities.