### PR TITLE
docs: update changelog and version to v0.1.5b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## v0.1.5b2
+### Added
+- Support binary sensors to be displayed as text sensor entities and binary sensor entities. [#592](https://github.com/XiaoMi/ha_xiaomi_home/pull/592)
+- Add miot cloud test case. [#620](https://github.com/XiaoMi/ha_xiaomi_home/pull/620)
+- Add test case for user cert. [#638](https://github.com/XiaoMi/ha_xiaomi_home/pull/638)
+- Add mips test case & Change mips reconnect logic. [#641](https://github.com/XiaoMi/ha_xiaomi_home/pull/641)
+- Support remove device. [#622](https://github.com/XiaoMi/ha_xiaomi_home/pull/622)
+- Support italian translation. [#183](https://github.com/XiaoMi/ha_xiaomi_home/pull/183)
+### Changed
+- Refactor miot spec. [#592](https://github.com/XiaoMi/ha_xiaomi_home/pull/592)
+- Refactor miot mips & fix type errors. [#365](https://github.com/XiaoMi/ha_xiaomi_home/pull/365)
+- Using logging for test case log print. [#636](https://github.com/XiaoMi/ha_xiaomi_home/pull/636)
+- Add power properties trans. [#571](https://github.com/XiaoMi/ha_xiaomi_home/pull/571)
+- Move web page to html. [#627](https://github.com/XiaoMi/ha_xiaomi_home/pull/627)
+### Fixed
+- Fix miot cloud and mdns error. [#637](https://github.com/XiaoMi/ha_xiaomi_home/pull/637)
+- Fix type error
+
 ## v0.1.5b1
 This version will cause some Xiaomi routers that do not support access (#564) to become unavailable. You can update the device list in the configuration or delete it manually.
 ### Added

--- a/custom_components/xiaomi_home/manifest.json
+++ b/custom_components/xiaomi_home/manifest.json
@@ -25,7 +25,7 @@
         "cryptography",
         "psutil"
     ],
-    "version": "v0.1.5b1",
+    "version": "v0.1.5b2",
     "zeroconf": [
         "_miot-central._tcp.local."
     ]


### PR DESCRIPTION
## v0.1.5b2
### Added
- Support binary sensors to be displayed as text sensor entities and binary sensor entities. [#592](https://github.com/XiaoMi/ha_xiaomi_home/pull/592)
- Add miot cloud test case. [#620](https://github.com/XiaoMi/ha_xiaomi_home/pull/620)
- Add test case for user cert. [#638](https://github.com/XiaoMi/ha_xiaomi_home/pull/638)
- Add mips test case & Change mips reconnect logic. [#641](https://github.com/XiaoMi/ha_xiaomi_home/pull/641)
- Support remove device. [#622](https://github.com/XiaoMi/ha_xiaomi_home/pull/622)
- Support italian translation. [#183](https://github.com/XiaoMi/ha_xiaomi_home/pull/183)
### Changed
- Refactor miot spec. [#592](https://github.com/XiaoMi/ha_xiaomi_home/pull/592)
- Refactor miot mips & fix type errors. [#365](https://github.com/XiaoMi/ha_xiaomi_home/pull/365)
- Using logging for test case log print. [#636](https://github.com/XiaoMi/ha_xiaomi_home/pull/636)
- Add power properties trans. [#571](https://github.com/XiaoMi/ha_xiaomi_home/pull/571)
- Move web page to html. [#627](https://github.com/XiaoMi/ha_xiaomi_home/pull/627)
### Fixed
- Fix miot cloud and mdns error. [#637](https://github.com/XiaoMi/ha_xiaomi_home/pull/637)
- Fix type error