### PR TITLE
feat: add entity_category for indicator-light

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -57,6 +57,7 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     DEGREE,
+    EntityCategory,
     LIGHT_LUX,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS,
@@ -549,6 +550,9 @@ class MIoTDevice:
         # Optional actions
         # Optional events
         miot_service.platform = platform
+        # entity_category:
+        if entity_category := SPEC_SERVICE_TRANS_MAP[service_name].get('entity_category'):
+            miot_service.entity_category = entity_category
         return entity_data
 
     def parse_miot_property_entity(self, miot_prop: MIoTSpecProperty) -> bool:
@@ -899,6 +903,7 @@ class MIoTServiceEntity(Entity):
             self._attr_name = (
                 f'{"* "if self.entity_data.spec.proprietary else " "}'
                 f'{self.entity_data.spec.description_trans}')
+            self._attr_entity_category = entity_data.spec.entity_category
         # Set entity attr
         self._attr_unique_id = self.entity_id
         self._attr_should_poll = False

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -550,8 +550,9 @@ class MIoTDevice:
         # Optional actions
         # Optional events
         miot_service.platform = platform
-        # entity_category:
-        if entity_category := SPEC_SERVICE_TRANS_MAP[service_name].get('entity_category'):
+        # entity_category
+        if entity_category := SPEC_SERVICE_TRANS_MAP[service_name].get(
+            'entity_category', None):
             miot_service.entity_category = entity_category
         return entity_data
 

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -57,7 +57,6 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
     DEGREE,
-    EntityCategory,
     LIGHT_LUX,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS,

--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -476,6 +476,7 @@ class _MIoTSpecBase:
     device_class: Any
     state_class: Any
     external_unit: Any
+    entity_category: str | None
 
     spec_id: int
 
@@ -494,6 +495,7 @@ class _MIoTSpecBase:
         self.device_class = None
         self.state_class = None
         self.external_unit = None
+        self.entity_category = None
 
         self.spec_id = hash(f'{self.type_}.{self.iid}')
 

--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -465,7 +465,7 @@ class _MIoTSpecBase:
     iid: int
     type_: str
     description: str
-    description_trans: str
+    description_trans: Optional[str]
     proprietary: bool
     need_filter: bool
     name: str
@@ -476,7 +476,7 @@ class _MIoTSpecBase:
     device_class: Any
     state_class: Any
     external_unit: Any
-    entity_category: str | None
+    entity_category: Optional[str]
 
     spec_id: int
 

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -51,6 +51,7 @@ from homeassistant.components.event import EventDeviceClass
 
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    EntityCategory,
     LIGHT_LUX,
     UnitOfEnergy,
     UnitOfPower,
@@ -264,7 +265,8 @@ SPEC_DEVICE_TRANS_MAP: dict = {
             'events': set<event instance name: str>,
             'actions': set<action instance name: str>
         },
-        'entity': str
+        'entity': str,
+        'entity_category'?: str,
     }
 }
 """
@@ -282,10 +284,23 @@ SPEC_SERVICE_TRANS_MAP: dict = {
         },
         'entity': 'light'
     },
-    'indicator-light': 'light',
     'ambient-light': 'light',
     'night-light': 'light',
     'white-light': 'light',
+    'indicator-light': {
+        'required': {
+            'properties': {
+                'on': {'read', 'write'}
+            }
+        },
+        'optional': {
+            'properties': {
+                'mode', 'brightness',
+            }
+        },
+        'entity': 'light',
+        'entity_category': EntityCategory.CONFIG,
+    },
     'fan': {
         'required': {
             'properties': {

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -332,7 +332,7 @@ SPEC_DEVICE_TRANS_MAP: dict = {
             'actions': set<action instance name: str>
         },
         'entity': str,
-        'entity_category'?: str,
+        'entity_category'?: str
     }
 }
 """
@@ -365,7 +365,7 @@ SPEC_SERVICE_TRANS_MAP: dict = {
             }
         },
         'entity': 'light',
-        'entity_category': EntityCategory.CONFIG,
+        'entity_category': EntityCategory.CONFIG
     },
     'fan': {
         'required': {


### PR DESCRIPTION
# Why

When user turn off lights in an area, the indicator-light will also be turned off.

当用户通过 `light.turn_on` 或者 `light.turn_off` 控制某个房间的时候，指示灯也会被一起控制。
因为指示灯现在也是 `light`，添加 `entity_cateory`: `EntityCategory.CONFIG` 可以解决这个问题。

https://github.com/XiaoMi/ha_xiaomi_home/discussions/696

https://developers.home-assistant.io/docs/core/entity/#registry-properties

> Classification of a non-primary entity. Set to EntityCategory.CONFIG for an entity that allows changing the configuration of a device, for example, a switch entity, making it possible to turn the background illumination of a switch on and off. Set to EntityCategory.DIAGNOSTIC for an entity exposing some configuration parameter or diagnostics of a device but does not allow changing it, for example, a sensor showing RSSI or MAC address.


# Added

Added a new configuration item to `SPEC_SERVICE_TRANS_MAP`

Set the `EntityCategory` for `indicator-light` to `CONFIG`


# Further

Assign the appropriate EntityCategory to other entities so they can be easily identified and correctly classified.