### PR TITLE
fix: fix sensor display precision

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -540,7 +540,7 @@ class MIoTSpecProperty(_MIoTSpecBase):
         self.unit = unit
         self.value_range = value_range
         self.value_list = value_list
-        self.precision = precision or 1
+        self.precision = precision if precision is not None else 1
         self.expr = expr
 
         self.spec_id = hash(


### PR DESCRIPTION
Fix issue where `precision=0` was incorrectly defaulting to `1`.