### PR TITLE
fix: some `event:motion-detected` does not contain `'arguments'`

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -1213,10 +1213,12 @@ class MipsLocalClient(_MipsClient):
                 or 'did' not in msg
                 or 'siid' not in msg
                 or 'eiid' not in msg
-                or 'arguments' not in msg
+                # or 'arguments' not in msg
             ):
                 # self.log_error(f'on_event_msg, recv unknown msg, {payload}')
                 return
+            if 'arguments' not in msg:
+                msg['arguments'] = []
             if handler:
                 self.log_debug('local, on event_occurred, %s', payload)
                 handler(msg, ctx)


### PR DESCRIPTION
fix #651 
fix #667 

---

追踪了一下，问题出在 有些设备上报事件的时候没有`arguments`参数，在这里被拦住了。（例如 [米家夜灯2 蓝牙版 (yeelink.light.nl1)](https://home.miot-spec.com/spec/yeelink.light.nl1) 和 [小米人体传感器2 (lumi.motion.bmgl01)](https://home.miot-spec.com/spec/lumi.motion.bmgl01)）

简单做了一下默认值处理，经测试可行。