### PR TITLE
Fix wrong binary sensor state

### DIFF
--- a/custom_components/xiaomi_home/binary_sensor.py
+++ b/custom_components/xiaomi_home/binary_sensor.py
@@ -88,5 +88,5 @@ class BinarySensor(MIoTPropertyEntity, BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        """On/Off state. True if the binary sensor is on, False otherwise."""
-        return self._value is True
+        """On/Off state. False if the binary sensor is on, False otherwise."""
+        return self._value is False


### PR DESCRIPTION
"Contact closed" equals "State on." For example, in the case of a window, "contact closed" means "window open." However, with a closed contact, the window is open. Therefore, "contact closed" equals "State off."