### PR TITLE
feat: avoid setting icon when device_class is defined

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -591,13 +591,8 @@ class MIoTDevice:
             # Priority: spec_modify.unit > unit_convert > specv2entity.unit
             miot_prop.external_unit = SPEC_PROP_TRANS_MAP['properties'][
                 prop_name]['unit_of_measurement']
-        if (
-            not miot_prop.icon
-            and 'icon' in SPEC_PROP_TRANS_MAP['properties'][prop_name]
-        ):
-            # Priority: spec_modify.icon > icon_convert > specv2entity.icon
-            miot_prop.icon = SPEC_PROP_TRANS_MAP['properties'][prop_name][
-                'icon']
+        # Priority: default.icon when device_class is set > spec_modify.icon
+        #           > icon_convert
         miot_prop.platform = platform
         return True
 

--- a/custom_components/xiaomi_home/number.py
+++ b/custom_components/xiaomi_home/number.py
@@ -88,7 +88,7 @@ class Number(MIoTPropertyEntity, NumberEntity):
         if self.spec.external_unit:
             self._attr_native_unit_of_measurement = self.spec.external_unit
         # Set icon
-        if self.spec.icon:
+        if self.spec.icon and not self.device_class:
             self._attr_icon = self.spec.icon
         # Set value range
         if self._value_range:

--- a/custom_components/xiaomi_home/sensor.py
+++ b/custom_components/xiaomi_home/sensor.py
@@ -116,7 +116,7 @@ class Sensor(MIoTPropertyEntity, SensorEntity):
             if spec.state_class:
                 self._attr_state_class = spec.state_class
         # Set icon
-        if spec.icon:
+        if spec.icon and not self.device_class:
             self._attr_icon = spec.icon
 
     @property


### PR DESCRIPTION
建议：有 `device_class` 的实体不要设置 icon 了，HA有一套默认的图标。这样例如电池的实体图标也会随着电量自动变化。

https://github.com/XiaoMi/ha_xiaomi_home/discussions/278