### PR TITLE
fix: MIoT-Spec-V2 conflicts of xiaomi.fan.p5 and mike.bhf_light.2

### DIFF
--- a/custom_components/xiaomi_home/event.py
+++ b/custom_components/xiaomi_home/event.py
@@ -46,6 +46,7 @@ off Xiaomi or its affiliates' products.
 Event entities for Xiaomi Home.
 """
 from __future__ import annotations
+import logging
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -56,6 +57,8 @@ from homeassistant.components.event import EventEntity
 from .miot.miot_spec import MIoTSpecEvent
 from .miot.miot_device import MIoTDevice, MIoTEventEntity
 from .miot.const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -89,4 +92,5 @@ class Event(MIoTEventEntity, EventEntity):
         self, name: str, arguments: dict[str, Any] | None = None
     ) -> None:
         """An event is occurred."""
+        _LOGGER.debug('%s, attributes: %s', name, str(arguments))
         self._trigger_event(event_type=name, event_attributes=arguments)

--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -1215,9 +1215,10 @@ class MipsLocalClient(_MipsClient):
                 or 'eiid' not in msg
                 # or 'arguments' not in msg
             ):
-                # self.log_error(f'on_event_msg, recv unknown msg, {payload}')
+                self.log_error('unknown event msg, %s', payload)
                 return
             if 'arguments' not in msg:
+                self.log_info('wrong event msg, %s', payload)
                 msg['arguments'] = []
             if handler:
                 self.log_debug('local, on event_occurred, %s', payload)

--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -1205,6 +1205,9 @@ class _SpecModify:
         if isinstance(self._selected, str):
             return await self.set_spec_async(urn=self._selected)
 
+    def get_prop_name(self, siid: int, piid: int) -> Optional[str]:
+        return self.__get_prop_item(siid=siid, piid=piid, key='name')
+
     def get_prop_unit(self, siid: int, piid: int) -> Optional[str]:
         return self.__get_prop_item(siid=siid, piid=piid, key='unit')
 
@@ -1518,6 +1521,10 @@ class MIoTSpecParser:
                     siid=service['iid'], piid=property_['iid'])
                 if custom_range:
                     spec_prop.value_range = custom_range
+                custom_name = self._spec_modify.get_prop_name(
+                    siid=service['iid'], piid=property_['iid'])
+                if custom_name:
+                    spec_prop.name = custom_name
             # Parse service event
             for event in service.get('events', []):
                 if (

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -58,3 +58,13 @@ urn:miot-spec-v2:device:bath-heater:0000A028:opple-acmoto:1:
       description: medium
     - value: 255
       description: high
+urn:miot-spec-v2:device:bath-heater:0000A028:mike-2:1:
+  prop.3.1:
+    name: mode-a
+  prop.3.11:
+    name: mode-b
+  prop.3.12:
+    name: mode-c
+urn:miot-spec-v2:device:fan:0000A005:xiaomi-p51:1:
+  prop.2.2:
+    name: fan-level-a


### PR DESCRIPTION
To solve #736 #864 

# Added
- Modify the name of the MIoT-Spec-V2 property instance.
- Necessary logs for the event entity.