### PR TITLE
fix: on/off feature initialization

### DIFF
--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -488,7 +488,7 @@ class AirConditioner(FeatureOnOff, FeatureTargetTemperature,
         # hvac modes
         self._attr_hvac_modes = None
         for prop in entity_data.props:
-            if prop.name == 'mode':
+            if prop.name == 'mode' and prop.service.name == 'air-conditioner':
                 if not prop.value_list:
                     _LOGGER.error('invalid mode value_list, %s', self.entity_id)
                     continue
@@ -623,7 +623,7 @@ class PtcBathHeater(FeatureTargetTemperature, FeatureTemperature,
         self._attr_icon = 'mdi:hvac'
         # hvac modes
         for prop in entity_data.props:
-            if prop.name == 'mode':
+            if prop.name == 'mode' and prop.service.name == 'ptc-bath-heater':
                 if not prop.value_list:
                     _LOGGER.error('invalid mode value_list, %s', self.entity_id)
                     continue

--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -114,6 +114,7 @@ class FeatureOnOff(MIoTServiceEntity, ClimateEntity):
                 self._attr_supported_features |= ClimateEntityFeature.TURN_ON
                 self._attr_supported_features |= ClimateEntityFeature.TURN_OFF
                 self._prop_on = prop
+                break
 
     async def async_turn_on(self) -> None:
         """Turn on."""
@@ -150,6 +151,7 @@ class FeatureTargetTemperature(MIoTServiceEntity, ClimateEntity):
                 self._attr_supported_features |= (
                     ClimateEntityFeature.TARGET_TEMPERATURE)
                 self._prop_target_temp = prop
+                break
         # temperature_unit is required by the climate entity
         if not self._attr_temperature_unit:
             self._attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -199,6 +201,7 @@ class FeaturePresetMode(MIoTServiceEntity, ClimateEntity):
                 self._attr_supported_features |= (
                     ClimateEntityFeature.PRESET_MODE)
                 self._prop_mode = prop
+                break
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
@@ -367,6 +370,7 @@ class FeatureTemperature(MIoTServiceEntity, ClimateEntity):
         for prop in entity_data.props:
             if prop.name == 'temperature':
                 self._prop_env_temperature = prop
+                break
 
     @property
     def current_temperature(self) -> Optional[float]:
@@ -389,6 +393,7 @@ class FeatureHumidity(MIoTServiceEntity, ClimateEntity):
         for prop in entity_data.props:
             if prop.name == 'relative-humidity':
                 self._prop_env_humidity = prop
+                break
 
     @property
     def current_humidity(self) -> Optional[float]:
@@ -420,6 +425,7 @@ class FeatureTargetHumidity(MIoTServiceEntity, ClimateEntity):
                 self._attr_supported_features |= (
                     ClimateEntityFeature.TARGET_HUMIDITY)
                 self._prop_target_humidity = prop
+                break
 
     async def async_set_humidity(self, humidity):
         """Set the target humidity."""

--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -51,6 +51,7 @@ from typing import Any, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.components.climate import (
     FAN_ON, FAN_OFF, SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL,
@@ -133,6 +134,7 @@ class FeatureTargetTemperature(MIoTServiceEntity, ClimateEntity):
                  entity_data: MIoTEntityData) -> None:
         """Initialize the feature class."""
         self._prop_target_temp = None
+        self._attr_temperature_unit = None
 
         super().__init__(miot_device=miot_device, entity_data=entity_data)
         # properties
@@ -150,6 +152,9 @@ class FeatureTargetTemperature(MIoTServiceEntity, ClimateEntity):
                 self._attr_supported_features |= (
                     ClimateEntityFeature.TARGET_TEMPERATURE)
                 self._prop_target_temp = prop
+        # temperature_unit is required by the climate entity
+        if not self._attr_temperature_unit:
+            self._attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     async def async_set_temperature(self, **kwargs):
         """Set the target temperature."""

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -76,3 +76,8 @@ urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:2: urn:miot-spec-v2:d
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:3: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:4: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:5: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6
+urn:miot-spec-v2:device:airer:0000A00D:mrbond-m33a:1:
+  prop.2.3:
+    name: current-position-a
+  prop.2.11:
+    name: current-position-b

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -81,3 +81,38 @@ urn:miot-spec-v2:device:airer:0000A00D:mrbond-m33a:1:
     name: current-position-a
   prop.2.11:
     name: current-position-b
+urn:miot-spec-v2:device:thermostat:0000A031:suittc-wk168:1:
+  prop.2.3:
+    value-list:
+    - value: 1
+      description: one
+    - value: 2
+      description: two
+    - value: 3
+      description: three
+    - value: 4
+      description: four
+    - value: 5
+      description: five
+    - value: 6
+      description: six
+    - value: 7
+      description: seven
+    - value: 8
+      description: eight
+    - value: 9
+      description: nine
+    - value: 10
+      description: ten
+    - value: 11
+      description: eleven
+    - value: 12
+      description: twelve
+    - value: 13
+      description: thirteen
+    - value: 14
+      description: fourteen
+    - value: 15
+      description: fifteen
+    - value: 16
+      description: sixteen


### PR DESCRIPTION
To solve #877 #886 

# Why
- The device with multiple climate services like air-conditioner, thermostat, heater and electric-blanket will be converted to several climate entities. These entities' on/off switch is linked to the on property of the air-conditioner service, the thermostat service, the heater and the electric-blanket serivce respectively. 
- [temperature_unit is required by the climate entity](https://developers.home-assistant.io/docs/core/entity/climate/#properties). If temperature_unit is not specified, the entity will not be added to hass successfully.
