### PR TITLE
feat: make submersion-state, contact-state, occupancy-status as binary_sensor

### DIFF
--- a/custom_components/xiaomi_home/binary_sensor.py
+++ b/custom_components/xiaomi_home/binary_sensor.py
@@ -89,4 +89,8 @@ class BinarySensor(MIoTPropertyEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """On/Off state. True if the binary sensor is on, False otherwise."""
+        if self.spec.name == 'contact-state':
+            return self._value is False
+        elif self.spec.name == 'occupancy-status':
+            return bool(self._value)
         return self._value is True

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -48,6 +48,7 @@ Conversion rules of MIoT-Spec-V2 instance to Home Assistant entity.
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.components.event import EventDeviceClass
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -454,12 +455,28 @@ SPEC_PROP_TRANS_MAP: dict = {
             'format': {'int', 'float'},
             'access': {'read'}
         },
+        'binary_sensor': {
+            'format': {'bool', 'int', 'float'},
+            'access': {'read'}
+        },
         'switch': {
             'format': {'bool'},
             'access': {'read', 'write'}
         }
     },
     'properties': {
+        'submersion-state': {
+            'device_class': BinarySensorDeviceClass.MOISTURE,
+            'entity': 'binary_sensor'
+        },
+        'contact-state': {
+            'device_class': BinarySensorDeviceClass.DOOR,
+            'entity': 'binary_sensor'
+        },
+        'occupancy-status': {
+            'device_class': BinarySensorDeviceClass.OCCUPANCY,
+            'entity': 'binary_sensor',
+        },
         'temperature': {
             'device_class': SensorDeviceClass.TEMPERATURE,
             'entity': 'sensor',

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -456,7 +456,7 @@ SPEC_PROP_TRANS_MAP: dict = {
             'access': {'read'}
         },
         'binary_sensor': {
-            'format': {'bool', 'int', 'float'},
+            'format': {'bool', 'int'},
             'access': {'read'}
         },
         'switch': {


### PR DESCRIPTION
雨感状态、接触状态、有人无人状态 实体类型调整为 `binary_sensor`，并添加对应的 `device_class`。

fix #206 
fix #741 
fix #775 
fix #809 

另外也有相当多的讨论都提出了相同的建议：
https://github.com/XiaoMi/ha_xiaomi_home/discussions/914
https://github.com/XiaoMi/ha_xiaomi_home/discussions/897
https://github.com/XiaoMi/ha_xiaomi_home/discussions/653
https://github.com/XiaoMi/ha_xiaomi_home/discussions/485
https://github.com/XiaoMi/ha_xiaomi_home/discussions/449
https://github.com/XiaoMi/ha_xiaomi_home/discussions/345
https://github.com/XiaoMi/ha_xiaomi_home/discussions/184

