### PR TITLE
Fix specs

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -168,5 +168,11 @@
             "service:016:action:001": "中键确认",
             "service:017:action:001": "右键确认"
         }
+    },
+    "urn:miot-spec-v2:device:bath-heater:0000A028:yeelink-v10": {
+        "en": {
+            "service:003:property:001:valuelist:000": "Idle",
+            "service:003:property:001:valuelist:001": "Dry"
+        }
     }
 }

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -116,3 +116,8 @@ urn:miot-spec-v2:device:thermostat:0000A031:suittc-wk168:1:
       description: fifteen
     - value: 16
       description: sixteen
+urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3:
+  prop.5.1:
+    expr: round(src_value*6/1000000, 3)
+urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:1: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
+urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:2: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3

--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -560,12 +560,6 @@ SPEC_PROP_TRANS_MAP: dict = {
             'entity': 'sensor',
             'state_class': SensorStateClass.MEASUREMENT,
             'unit_of_measurement': UnitOfPower.WATT
-        },
-        'total-battery': {
-            'device_class': SensorDeviceClass.ENERGY,
-            'entity': 'sensor',
-            'state_class': SensorStateClass.TOTAL_INCREASING,
-            'unit_of_measurement': UnitOfEnergy.KILO_WATT_HOUR
         }
     }
 }


### PR DESCRIPTION
# Why
- #908 : The ptc-bath-heater mode value-list description in English [configuration](https://miot-spec.org/instance/v2/multiLanguage?urn=urn:miot-spec-v2:device:bath-heater:0000A028:yeelink-v10:1) configured by the manufacturer is ambiguous.
- #788 : The power consumption value of chuangmi.plug.212a01 is in unit mWh.
- There is no total-battery property in [MIoT-Spec-V2 properties](https://miot-spec.org/miot-spec-v2/spec/properties).