### PR TITLE
Update spec_modify.yaml

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -85,37 +85,37 @@ urn:miot-spec-v2:device:thermostat:0000A031:suittc-wk168:1:
   prop.2.3:
     value-list:
     - value: 1
-      description: one
+      description: '1'
     - value: 2
-      description: two
+      description: '2'
     - value: 3
-      description: three
+      description: '3'
     - value: 4
-      description: four
+      description: '4'
     - value: 5
-      description: five
+      description: '5'
     - value: 6
-      description: six
+      description: '6'
     - value: 7
-      description: seven
+      description: '7'
     - value: 8
-      description: eight
+      description: '8'
     - value: 9
-      description: nine
+      description: '9'
     - value: 10
-      description: ten
+      description: '10'
     - value: 11
-      description: eleven
+      description: '11'
     - value: 12
-      description: twelve
+      description: '12'
     - value: 13
-      description: thirteen
+      description: '13'
     - value: 14
-      description: fourteen
+      description: '14'
     - value: 15
-      description: fifteen
+      description: '15'
     - value: 16
-      description: sixteen
+      description: '16'
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3:
   prop.5.1:
     expr: round(src_value*6/1000000, 3)


### PR DESCRIPTION
之前调整为英文数字与厂家原始设置不符，也无法根据数字进行进一步的判断设置辅助元素和自动化，如判断温控器是否启动加热可以用下方模板二元传感器：

{{ state_attr('climate.suittc_cn_427910564_wk168', 'preset_mode') >= '8' }}

因此建议调整转换文字

调整后实测属性转换为数字，基础功能及辅助元素运行正常