### PR TITLE
fix: correct unit,icon and translations for hhcc-v1

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -174,5 +174,14 @@
             "service:003:property:001:valuelist:000": "Idle",
             "service:003:property:001:valuelist:001": "Dry"
         }
+    },
+    "urn:miot-spec-v2:device:plant-monitor:0000A030:hhcc-v1": {
+        "en": {
+            "service:002:property:001": "Soil Moisture"
+        },
+        "zh-Hans": {
+            "service:002:property:001": "土壤湿度",
+            "service:002:property:003": "光照强度"
+        }
     }
 }

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -123,6 +123,7 @@ urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:1: urn:miot-spec-v2:devi
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:2: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
 urn:miot-spec-v2:device:plant-monitor:0000A030:hhcc-v1:1:
     prop.2.1:
+      name: moisture
       icon: mdi:watering-can
     prop.2.2:
       name: soil-ec

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -123,9 +123,8 @@ urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:1: urn:miot-spec-v2:devi
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:2: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
 urn:miot-spec-v2:device:plant-monitor:0000A030:hhcc-v1:1:
     prop.2.1:
-      name: moisture
       icon: mdi:watering-can
     prop.2.2:
-      name: soil_ec
+      name: soil-ec
       icon: mdi:sprout-outline
       unit: μS/cm

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -123,7 +123,7 @@ urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:1: urn:miot-spec-v2:devi
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:2: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
 urn:miot-spec-v2:device:plant-monitor:0000A030:hhcc-v1:1:
     prop.2.1:
-      name: moisture
+      name: soil-moisture
       icon: mdi:watering-can
     prop.2.2:
       name: soil-ec

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -121,3 +121,11 @@ urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3:
     expr: round(src_value*6/1000000, 3)
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:1: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
 urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:2: urn:miot-spec-v2:device:outlet:0000A002:chuangmi-212a01:3
+urn:miot-spec-v2:device:plant-monitor:0000A030:hhcc-v1:1:
+    prop.2.1:
+      name: moisture
+      icon: mdi:watering-can
+    prop.2.2:
+      name: soil_ec
+      icon: mdi:sprout-outline
+      unit: μS/cm


### PR DESCRIPTION
# Why
Fix the unit and icon for hhcc-v1 to let Home Assistant correctly display the history chart.

操作错了，把上一个PR关了，写`name: moisture`是因为只改icon没反应