### PR TITLE
fix: add migration step for config entry

### DIFF
--- a/custom_components/xiaomi_home/__init__.py
+++ b/custom_components/xiaomi_home/__init__.py
@@ -354,7 +354,7 @@ async def async_remove_config_entry_device(
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old entry."""
     _LOGGER.debug(
-        "Migrating configuration from version %s.%s",
+        'Migrating configuration from version %s.%s',
         config_entry.version,
         config_entry.minor_version,
     )
@@ -367,7 +367,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         await _migrate_v1_to_v2(hass, config_entry)
 
     _LOGGER.debug(
-        "Migration to configuration version %s.%s successful",
+        'Migration to configuration version %s.%s successful',
         config_entry.version,
         config_entry.minor_version,
     )
@@ -413,8 +413,8 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
         loop=miot_client.main_loop)
     await manufacturer.init_async()
     er = entity_registry.async_get(hass)
-    for did, info in miot_client.device_list.items():
-        spec_instance = await spec_parser.parse(urn=info["urn"])
+    for _, info in miot_client.device_list.items():
+        spec_instance = await spec_parser.parse(urn=info['urn'])
         if not isinstance(spec_instance, MIoTSpecInstance):
             continue
         device: MIoTDevice = MIoTDevice(
@@ -426,15 +426,17 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
         device.spec_transform()
 
         # Update unique_id
-        for platform in device.entity_list:
-            for entity in device.entity_list[platform]:
+        for platform, entities in device.entity_list.items():
+            for entity in entities:
                 if not isinstance(entity.spec, MIoTSpecService):
                     continue
                 old_unique_id = device.gen_service_entity_id_v1(
                     ha_domain=DOMAIN,
                     siid=entity.spec.iid,
                 )
-                entity_id = er.async_get_entity_id(platform, DOMAIN, old_unique_id)
+                entity_id = er.async_get_entity_id(
+                    platform, DOMAIN, old_unique_id
+                )
                 if entity_id is None:
                     continue
                 new_unique_id = device.gen_service_entity_id(

--- a/custom_components/xiaomi_home/config_flow.py
+++ b/custom_components/xiaomi_home/config_flow.py
@@ -105,7 +105,7 @@ _LOGGER = logging.getLogger(__name__)
 class XiaomiMihomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Xiaomi Home config flow."""
     # pylint: disable=unused-argument, inconsistent-quotes
-    VERSION = 1
+    VERSION = 2
     MINOR_VERSION = 1
     DEFAULT_AREA_NAME_RULE = 'room'
     _main_loop: asyncio.AbstractEventLoop

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -345,6 +345,11 @@ class MIoTDevice:
             f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
             f'{self._model_strs[-1][:20]}')
 
+    def gen_service_entity_id_v1(self, ha_domain: str, siid: int) -> str:
+        return (
+            f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
+            f'{self._model_strs[-1][:20]}_s_{siid}')
+
     def gen_service_entity_id(self, ha_domain: str, siid: int,
                               description: str) -> str:
         return (


### PR DESCRIPTION
https://github.com/XiaoMi/ha_xiaomi_home/pull/953 的一处变更修改了部分实体的 `unique_id` ，这里添加一个迁移步骤，避免用户需要重新配置大量界面自动化等。


这里有大段代码(L379-L426) 我是复制自上方的 `async_setup_entry`，或许可以整理优化一下。