### PR TITLE
fix(spec): contact-state for linp.magnet.m1 and loock.safe.v1

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -84,6 +84,10 @@ urn:miot-spec-v2:device:gateway:0000A019:xiaomi-hub1:3: urn:miot-spec-v2:device:
 urn:miot-spec-v2:device:light:0000A001:shhf-sfla12:1:
   prop.8.11:
     name: on-a
+urn:miot-spec-v2:device:magnet-sensor:0000A016:linp-m1:1:  # linp.magnet.m1
+  prop.2.1004:
+    name: contact-state
+    expr: src_value!=1
 urn:miot-spec-v2:device:motion-sensor:0000A014:lumi-acn001:1:
   prop.3.2:
     access:
@@ -147,6 +151,10 @@ urn:miot-spec-v2:device:router:0000A036:xiaomi-rd08:1:
     name: upload-speed
     icon: mdi:upload
     unit: B/s
+urn:miot-spec-v2:device:safe-box:0000A042:loock-v1:1:  # loock.safe.v1
+  prop.5.1:
+    name: contact-state
+    expr: src_value!=0
 urn:miot-spec-v2:device:thermostat:0000A031:suittc-wk168:1:
   prop.2.3:
     value-list:

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -154,7 +154,7 @@ urn:miot-spec-v2:device:router:0000A036:xiaomi-rd08:1:
 urn:miot-spec-v2:device:safe-box:0000A042:loock-v1:1:  # loock.safe.v1
   prop.5.1:
     name: contact-state
-    expr: src_value!=0
+    expr: src_value!=1
 urn:miot-spec-v2:device:thermostat:0000A031:suittc-wk168:1:
   prop.2.3:
     value-list:


### PR DESCRIPTION
这两个设备用了 `status` 来定义开关状态，这里把 name 修改成 `contact-state`，这样可以作为 `binary_sensor` 来显示。

Fix #975