### PR TITLE
feat: make air-purifier as fan

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -389,6 +389,7 @@ SPEC_SERVICE_TRANS_MAP: dict = {
     'fan-control': 'fan',
     'ceiling-fan': 'fan',
     'air-fresh': 'fan',
+    'air-purifier': 'fan',
     'water-heater': {
         'required': {
             'properties': {


### PR DESCRIPTION
把空气净化器作为风扇显示。

air-purifier 和 fan 有非常多相似的地方，HA上也有很多其它集成都是把空气净化器设计成`fan`的。

已在 `zhimi.airp.ua1` 上测试