### PR TITLE
feat: modify MIoT-Spec-V2 property format

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_client.py
+++ b/custom_components/xiaomi_home/miot/miot_client.py
@@ -646,7 +646,8 @@ class MIoTClient:
                 result = await self._miot_lan.set_prop_async(
                     did=did, siid=siid, piid=piid, value=value)
                 _LOGGER.debug(
-                    'lan set prop, %s, %s, %s -> %s', did, siid, piid, result)
+                    'lan set prop, %s.%d.%d, %s -> %s',
+                    did, siid, piid, value, result)
                 rc = (result or {}).get(
                     'code', MIoTErrorCode.CODE_MIPS_INVALID_RESULT.value)
                 if rc in [0, 1]:

--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -1195,6 +1195,9 @@ class _SpecModify:
     def get_prop_unit(self, siid: int, piid: int) -> Optional[str]:
         return self.__get_prop_item(siid=siid, piid=piid, key='unit')
 
+    def get_prop_format(self, siid: int, piid: int) -> Optional[str]:
+        return self.__get_prop_item(siid=siid, piid=piid, key='format')
+
     def get_prop_expr(self, siid: int, piid: int) -> Optional[str]:
         return self.__get_prop_item(siid=siid, piid=piid, key='expr')
 
@@ -1518,6 +1521,10 @@ class MIoTSpecParser:
                     siid=service['iid'], piid=property_['iid'])
                 if custom_access:
                     spec_prop.access = custom_access
+                custom_format = self._spec_modify.get_prop_format(
+                    siid=service['iid'], piid=property_['iid'])
+                if custom_format:
+                    spec_prop.format_ = custom_format
                 custom_range = self._spec_modify.get_prop_value_range(
                     siid=service['iid'], piid=property_['iid'])
                 if custom_range:

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -1,3 +1,6 @@
+urn:miot-spec-v2:device:air-condition-outlet:0000A045:lumi-mcn04:1:
+  prop.3.4:
+    format: uint8
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:1: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:2: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6
 urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:3: urn:miot-spec-v2:device:air-conditioner:0000A004:xiaomi-m9:6


### PR DESCRIPTION
# Why
#980 : When xiaomi_home set the target temperature property (siid=3, piid=4) to 25.0 of lumi.acpartner.mcn04 through the LAN control, the device responded code=-4005 indicating that the value is invalid. I suspect that the device only supports a int value rather than a float value.

# Added
Modifying the MIoT-Spec-V2 property format by spec_modify.yaml