### PR TITLE
fix: mrbond.airer.m1t closing status

### DIFF
--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -161,7 +161,7 @@ class Cover(MIoTServiceEntity, CoverEntity):
                 for item in prop.value_list.items:
                     if item.name in {'opening', 'open', 'up'}:
                         self._prop_status_opening.append(item.value)
-                    elif item.name in {'closing', 'close', 'down'}:
+                    elif item.name in {'closing', 'close', 'down', 'dowm'}:
                         self._prop_status_closing.append(item.value)
                     elif item.name in {'stop', 'stopped', 'pause'}:
                         self._prop_status_stop.append(item.value)

--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -26,6 +26,9 @@ urn:miot-spec-v2:device:airer:0000A00D:hyd-znlyj5:1:
     - 1
     - 1
 urn:miot-spec-v2:device:airer:0000A00D:hyd-znlyj5:2: urn:miot-spec-v2:device:airer:0000A00D:hyd-znlyj5:1
+urn:miot-spec-v2:device:airer:0000A00D:mrbond-m1t:1:
+  prop.2.3:
+    name: current-position-a
 urn:miot-spec-v2:device:airer:0000A00D:mrbond-m33a:1:
   prop.2.3:
     name: current-position-a


### PR DESCRIPTION
To solve #1059 

# Why
[mrbond.airer.m1t](https://home.miot-spec.com/spec/mrbond.airer.m1t) status property's value-list, "Down" is mistakenly written as "Dowm".

# Changed
There are two current-position properties in airer service (siid=2). siid=2, piid=11 is the true current-position property.Thus, siid=2, piid=3 property is removed from the cover entity.
