### PR TITLE
fix: tofan.airrtc.wk01 thermostat and air conditioner service

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_client.py
+++ b/custom_components/xiaomi_home/miot/miot_client.py
@@ -629,11 +629,14 @@ class MIoTClient:
                 mips = self._mips_local.get(device_gw['group_id'], None)
                 if mips is None:
                     _LOGGER.error(
-                        'no gw route, %s, try control through cloud',
+                        'no gateway route, %s, try control through cloud',
                         device_gw)
                 else:
                     result = await mips.set_prop_async(
                         did=did, siid=siid, piid=piid, value=value)
+                    _LOGGER.debug(
+                        'gateway set prop, %s.%d.%d, %s -> %s',
+                        did, siid, piid, value, result)
                     rc = (result or {}).get(
                         'code', MIoTErrorCode.CODE_MIPS_INVALID_RESULT.value)
                     if rc in [0, 1]:
@@ -663,7 +666,7 @@ class MIoTClient:
                     {'did': did, 'siid': siid, 'piid': piid, 'value': value}
                 ])
             _LOGGER.debug(
-                'set prop response, %s.%d.%d, %s, result, %s',
+                'cloud set prop, %s.%d.%d, %s -> %s',
                 did, siid, piid, value, result)
             if result and len(result) == 1:
                 rc = result[0].get(

--- a/custom_components/xiaomi_home/miot/specs/multi_lang.json
+++ b/custom_components/xiaomi_home/miot/specs/multi_lang.json
@@ -261,6 +261,17 @@
       "service:004:property:007": "минимальная температура цели "
     }
   },
+  "urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01": {
+    "en": {
+      "service:002": "Thermostat",
+      "service:002:property:002": "Air Conditioner Mode",
+      "service:004": "Air Conditioner"
+    },
+    "zh_cn": {
+      "service:002": "地暖",
+      "service:004": "空调"
+    }
+  },
   "urn:miot-spec-v2:device:vacuum:0000A006:ijai-v1": {
     "zh_cn": {
       "service:007:property:005:valuelist:000": "安静",

--- a/custom_components/xiaomi_home/miot/specs/spec_add.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_add.json
@@ -19,6 +19,165 @@
       ]
     }
   ],
+  "urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01:1:0000C822": [
+    {
+      "iid": 2,
+      "type": "urn:miot-spec-v2:service:thermostat:0000784A:tofan-wk01:1",
+      "description": "Air Conditioner",
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:on:00000006:tofan-wk01:1",
+          "description": "Switch Status",
+          "format": "bool",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ]
+        },
+        {
+          "iid": 2,
+          "type": "urn:miot-spec-v2:property:mode-a:00000008:tofan-wk01:1",
+          "description": "Mode",
+          "format": "uint8",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ],
+          "value-list": [
+            {
+              "value": 0,
+              "description": "Auto"
+            },
+            {
+              "value": 1,
+              "description": "Cool"
+            },
+            {
+              "value": 2,
+              "description": "Heat"
+            },
+            {
+              "value": 3,
+              "description": "Fan"
+            },
+            {
+              "value": 4,
+              "description": "Dry"
+            }
+          ]
+        },
+        {
+          "iid": 3,
+          "type": "urn:miot-spec-v2:property:fault:00000009:tofan-wk01:1",
+          "description": "Device Fault",
+          "format": "uint8",
+          "access": [
+            "read",
+            "notify"
+          ],
+          "value-list": [
+            {
+              "value": 0,
+              "description": "No Faults"
+            }
+          ]
+        },
+        {
+          "iid": 4,
+          "type": "urn:miot-spec-v2:property:target-temperature:00000021:tofan-wk01:1",
+          "description": "Target Temperature",
+          "format": "uint8",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ],
+          "unit": "celsius",
+          "value-range": [
+            16,
+            35,
+            1
+          ]
+        }
+      ],
+      "actions": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:action:toggle:00002811:tofan-wk01:1",
+          "description": "Toggle",
+          "in": [],
+          "out": []
+        }
+      ]
+    },
+    {
+      "iid": 4,
+      "type": "urn:miot-spec-v2:service:air-conditioner:0000780F:tofan-wk01:1",
+      "description": "Air Conditioner",
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:on:00000006:tofan-wk01:1",
+          "description": "Switch Status",
+          "format": "bool",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ]
+        },
+        {
+          "iid": 2,
+          "type": "urn:miot-spec-v2:property:target-temperature:00000021:tofan-wk01:1",
+          "description": "Target Temperature",
+          "format": "uint8",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ],
+          "unit": "celsius",
+          "value-range": [
+            16,
+            32,
+            1
+          ]
+        },
+        {
+          "iid": 3,
+          "type": "urn:miot-spec-v2:property:fan-level:00000016:tofan-wk01:1",
+          "description": "Fan Level",
+          "format": "uint8",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ],
+          "value-list": [
+            {
+              "value": 0,
+              "description": "Auto"
+            },
+            {
+              "value": 2,
+              "description": "Low"
+            },
+            {
+              "value": 3,
+              "description": "Medium"
+            },
+            {
+              "value": 4,
+              "description": "High"
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "urn:miot-spec-v2:device:water-heater:0000A02A:xiaomi-yms2:1": [
     {
       "iid": 2,

--- a/custom_components/xiaomi_home/miot/specs/spec_add.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_add.json
@@ -23,7 +23,7 @@
     {
       "iid": 2,
       "type": "urn:miot-spec-v2:service:thermostat:0000784A:tofan-wk01:1",
-      "description": "Air Conditioner",
+      "description": "Thermostat",
       "properties": [
         {
           "iid": 1,

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
@@ -44,3 +44,7 @@ urn:miot-spec-v2:device:motion-sensor:0000A014:xiaomi-pir1:
 urn:miot-spec-v2:device:router:0000A036:xiaomi-rd03:
   services:
   - '*'
+urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01:
+  services:
+  - '2'
+  - '4'


### PR DESCRIPTION
To solve #1148 

# Why
The device's [MIoT-Spec-V2](https://home.miot-spec.com/spec/tofan.airrtc.wk01) is not defined properly. As a matter of fact, siid=2 service is the thermostat service and siid=4 service is the air conditioner service. siid=2 piid=2 mode property is the hvac mode of the air conditioner service. It can be also confirmed by the [Chinese langurage configuration](https://miot-spec.org/instance/v2/multiLanguage?urn=urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01:1:0000C822).

# Changed
- Filter out original siid=2 and siid=4 service. Add siid=2 thermostat service and siid=4 air conditioner service. Set siid=2 piid=2 property's name as "mode-a" so that it will not be converted to the thermostat mode. Modify the multi-language configuration settings of Chinese and English.
- Modify Some debug prints.