### PR TITLE
fix: reconnect delay time

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -823,7 +823,7 @@ class _MipsClient(ABC):
         self._internal_loop.stop()
 
     def __get_next_reconnect_time(self) -> float:
-        if self._mips_reconnect_interval == 0:
+        if self._mips_reconnect_interval < self.MIPS_RECONNECT_INTERVAL_MIN:
             self._mips_reconnect_interval = self.MIPS_RECONNECT_INTERVAL_MIN
         else:
             self._mips_reconnect_interval = min(

--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -641,6 +641,7 @@ class _MipsClient(ABC):
         if not self._mqtt.is_connected():
             return
         self.log_info(f'mips connect, {flags}, {rc}, {props}')
+        self.__reset_reconnect_time()
         self._mqtt_state = True
         self._internal_loop.call_soon(
             self._on_mips_connect, rc, props)
@@ -829,6 +830,9 @@ class _MipsClient(ABC):
                 self._mips_reconnect_interval*2,
                 self.MIPS_RECONNECT_INTERVAL_MAX)
         return self._mips_reconnect_interval
+
+    def __reset_reconnect_time(self) -> None:
+        self._mips_reconnect_interval = 0
 
 
 class MipsCloudClient(_MipsClient):

--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -216,7 +216,7 @@ class _MipsClient(ABC):
     MQTT_INTERVAL_S = 1
     MIPS_QOS: int = 2
     UINT32_MAX: int = 0xFFFFFFFF
-    MIPS_RECONNECT_INTERVAL_MIN: float = 30
+    MIPS_RECONNECT_INTERVAL_MIN: float = 10
     MIPS_RECONNECT_INTERVAL_MAX: float = 600
     MIPS_SUB_PATCH: int = 300
     MIPS_SUB_INTERVAL: float = 1


### PR DESCRIPTION
# Why
If the reconnect delay time is not set to the default `MIPS_RECONNECT_INTERVAL_MIN` when xiaomi_home client is connected to the broker, the next delay time will alway be `MIPS_RECONNECT_INTERVAL_MAX` after several disconnections.

# Changed
- The default reconnect delay time is set to be 10 seconds.

# Fixed
- Set the reconnect delay time to be `MIPS_RECONNECT_INTERVAL_MIN` when the client is connected to the broker. 
