### PR TITLE
feat: exclude unsupported model

### DIFF
--- a/custom_components/xiaomi_home/miot/const.py
+++ b/custom_components/xiaomi_home/miot/const.py
@@ -85,6 +85,11 @@ SUPPORTED_PLATFORMS: list = [
     'water_heater',
 ]
 
+UNSUPPORTED_MODELS: list = [
+    'chuangmi.ir.v2',
+    'xiaomi.router.rd03'
+]
+
 DEFAULT_CLOUD_SERVER: str = 'cn'
 CLOUD_SERVERS: dict = {
     'cn': '中国大陆',

--- a/custom_components/xiaomi_home/miot/miot_cloud.py
+++ b/custom_components/xiaomi_home/miot/miot_cloud.py
@@ -59,6 +59,7 @@ import aiohttp
 # pylint: disable=relative-beyond-top-level
 from .common import calc_group_id
 from .const import (
+    UNSUPPORTED_MODELS,
     DEFAULT_OAUTH2_API_HOST,
     MIHOME_HTTP_API_TIMEOUT,
     OAUTH2_AUTH_URL)
@@ -572,6 +573,10 @@ class MIoTHttpClient:
                 # The miwifi.* routers defined SPEC functions, but none of them
                 # were implemented.
                 _LOGGER.info('ignore miwifi.* device, cloud, %s', did)
+                continue
+            if model in UNSUPPORTED_MODELS:
+                _LOGGER.info('ignore unsupported model %s, cloud, %s',
+                             model, did)
                 continue
             device_infos[did] = {
                 'did': did,

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1207,10 +1207,9 @@ class MIoTPropertyEntity(Entity):
         self._attr_available = miot_device.online
 
         _LOGGER.info(
-            'new miot property entity, %s, %s, %s, %s, %s, %s, %s',
+            'new miot property entity, %s, %s, %s, %s, %s',
             self.miot_device.name, self._attr_name, spec.platform,
-            spec.device_class, self.entity_id, self._value_range,
-            self._value_list)
+            spec.device_class, self.entity_id)
 
     @property
     def device_info(self) -> Optional[DeviceInfo]:

--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -68,7 +68,7 @@ from paho.mqtt.client import (
 
 # pylint: disable=relative-beyond-top-level
 from .common import MIoTMatcher
-from .const import MIHOME_MQTT_KEEPALIVE
+from .const import UNSUPPORTED_MODELS, MIHOME_MQTT_KEEPALIVE
 from .miot_error import MIoTErrorCode, MIoTMipsError
 
 _LOGGER = logging.getLogger(__name__)
@@ -1360,6 +1360,9 @@ class MipsLocalClient(_MipsClient):
             model: str = info.get('model', None)
             if name is None or urn is None or model is None:
                 self.log_error(f'invalid device info, {did}, {info}')
+                continue
+            if model in UNSUPPORTED_MODELS:
+                self.log_info(f'unsupported model, {model}, {did}')
                 continue
             device_list[did] = {
                 'did': did,

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
@@ -41,9 +41,6 @@ urn:miot-spec-v2:device:motion-sensor:0000A014:xiaomi-pir1:
   services:
   - '1'
   - '5'
-urn:miot-spec-v2:device:router:0000A036:xiaomi-rd03:
-  services:
-  - '*'
 urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01:
   services:
   - '2'


### PR DESCRIPTION
# Why
Xiaomi central hub gateway pushes all the online devices in the available device list to xiaomi_home no matter that some devices, like the infrared ray remote, the device without a valid MIoT-Spec-V2, are not supported by xiaomi_home. xiaomi_home must filter out the unsupport devices to avoid unnecessay device online notice. 

# Added
- Filter out unsupported device models at getting the device list from the MIoT cloud and Xiaomi central hub gateway.

# Changed
- Delete unused logs.