### PR TITLE
feat: subscribe the BLE device up messages even though the device is offline

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_client.py
+++ b/custom_components/xiaomi_home/miot/miot_client.py
@@ -983,13 +983,17 @@ class MIoTClient:
                 and self._device_list_lan[did].get('push_available', False)
             ):
                 from_new = 'lan'
-
         if (
             from_new is None
             and did in self._device_list_cloud
-            and self._device_list_cloud[did].get('online', False)
         ):
-            from_new = 'cloud'
+            # MIoT cloud service may not publish the online state updating
+            # message for the BLE device.
+            if did.startswith('blt.'):
+                from_new = 'cloud'
+            elif self._device_list_cloud[did].get('online', False):
+                from_new = 'cloud'
+
         if from_new == from_old:
             # No need to update
             return


### PR DESCRIPTION
# Why
xiaomi_home pulls all devices online state and property values at reloading. If the device is offline, xiaomi_home does not subscribe its topic `device/{did}/up/event_occured/#` or `device/{did}/up/properties_changed/#`, and xiaomi_home only subscribes `device/{did}/state/#`. When the device is online, xiaomi_home gets `device/{did}/state/online` message at which time xiaomi_home subscribes the topics `device/{did}/up/event_occured/#` and `device/{did}/up/properties_changed/#`.
The MIoT cloud may not publish the `device/{did}/state/online` message of BLE devices. Thus, if xiaomi_home reloads at a time that the BLE device is offline, it will never subscribe `device/{did}/up/event_occured/#` or `device/{did}/up/properties_changed/#`.
As a result, xiaomi_home can not get messages from an online BLE device.
# Changed
- Subscribe the BLE device's event_occured and properties_changed topics even if the BLE device is offline.