### PR TITLE
fix: support dmaker.fan.p5c fan-level

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/spec_add.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_add.json
@@ -217,5 +217,23 @@
         }
       ]
     }
+  ],
+  "urn:miot-spec-v2:device:fan:0000A005:dmaker-p5c:1": [
+    {
+      "iid": 8,
+      "type": "urn:miot-spec-v2:service:fan:00007808:dmaker-p5c:1",
+      "description": "Fan",
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:fan-level:00000016:dmaker-p5c:1",
+          "description": "Fan Level",
+          "format": "uint8",
+          "access": ["read", "notify", "write"],
+          "value-range": [1, 100, 1],
+          "gatt-access": []
+        }
+      ]
+    }
   ]
 }

--- a/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_filter.yaml
@@ -48,3 +48,7 @@ urn:miot-spec-v2:device:thermostat:0000A031:tofan-wk01:
   services:
   - '2'
   - '4'
+urn:miot-spec-v2:device:fan:00007808:dmaker-p5c:1:
+  properties:
+  - '2.2'
+  - '8.1'


### PR DESCRIPTION
fix #354, adds support for stepless speed level of the X1 fan (model: dmaker-p5c) by rewrite the MIoT device spec
