### PR TITLE
fix: airer status for cover entity

### DIFF
--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -159,7 +159,7 @@ class Cover(MIoTServiceEntity, CoverEntity):
                                   self.entity_id)
                     continue
                 for item in prop.value_list.items:
-                    if item.name in {'opening', 'open', 'up'}:
+                    if item.name in {'opening', 'open', 'up', 'rising'}:
                         self._prop_status_opening.append(item.value)
                     elif item.name in {'closing', 'close', 'down', 'dowm'}:
                         self._prop_status_closing.append(item.value)

--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -46,8 +46,9 @@ off Xiaomi or its affiliates' products.
 Cover entities for Xiaomi Home.
 """
 from __future__ import annotations
-import logging
 from typing import Any, Optional
+import re
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -157,16 +158,18 @@ class Cover(MIoTServiceEntity, CoverEntity):
                                   self.entity_id)
                     continue
                 for item in prop.value_list.items:
-                    if item.name in {
+                    item_str: str = item.name
+                    item_name: str = re.sub(r'[^a-z]', '', item_str)
+                    if item_name in {
                             'opening', 'open', 'up', 'uping', 'rise', 'rising'
                     }:
                         self._prop_status_opening.append(item.value)
-                    elif item.name in {
+                    elif item_name in {
                             'closing', 'close', 'down', 'dowm', 'falling',
                             'dropping', 'downing', 'lower'
                     }:
                         self._prop_status_closing.append(item.value)
-                    elif item.name in {
+                    elif item_name in {
                             'stopatlowest', 'stoplowerlimit', 'lowerlimitstop',
                             'floor', 'lowerlimit'
                     }:

--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -97,7 +97,6 @@ class Cover(MIoTServiceEntity, CoverEntity):
     _prop_status: Optional[MIoTSpecProperty]
     _prop_status_opening: Optional[list[int]]
     _prop_status_closing: Optional[list[int]]
-    _prop_status_stop: Optional[list[int]]
     _prop_status_closed: Optional[list[int]]
     _prop_current_position: Optional[MIoTSpecProperty]
     _prop_target_position: Optional[MIoTSpecProperty]
@@ -122,7 +121,6 @@ class Cover(MIoTServiceEntity, CoverEntity):
         self._prop_status = None
         self._prop_status_opening = []
         self._prop_status_closing = []
-        self._prop_status_stop = []
         self._prop_status_closed = []
         self._prop_current_position = None
         self._prop_target_position = None
@@ -159,13 +157,19 @@ class Cover(MIoTServiceEntity, CoverEntity):
                                   self.entity_id)
                     continue
                 for item in prop.value_list.items:
-                    if item.name in {'opening', 'open', 'up', 'rising'}:
+                    if item.name in {
+                            'opening', 'open', 'up', 'uping', 'rise', 'rising'
+                    }:
                         self._prop_status_opening.append(item.value)
-                    elif item.name in {'closing', 'close', 'down', 'dowm'}:
+                    elif item.name in {
+                            'closing', 'close', 'down', 'dowm', 'falling',
+                            'dropping', 'downing', 'lower'
+                    }:
                         self._prop_status_closing.append(item.value)
-                    elif item.name in {'stop', 'stopped', 'pause'}:
-                        self._prop_status_stop.append(item.value)
-                    elif item.name in {'closed'}:
+                    elif item.name in {
+                            'stopatlowest', 'stoplowerlimit', 'lowerlimitstop',
+                            'floor', 'lowerlimit'
+                    }:
                         self._prop_status_closed.append(item.value)
                 self._prop_status = prop
             elif prop.name == 'current-position':

--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -1178,7 +1178,7 @@ class MipsLocalClient(_MipsClient):
                 or 'piid' not in msg
                 or 'value' not in msg
             ):
-                # self.log_error(f'on_prop_msg, recv unknown msg, {payload}')
+                self.log_info('unknown prop msg, %s', payload)
                 return
             if handler:
                 self.log_debug('local, on properties_changed, %s', payload)


### PR DESCRIPTION
# Why
As of July 7, 2025, the statistical results are as follows.
| Circumstance | Number |
|---|---|
| airer service has only one status property | 167 |
| airer service has multiple status properties | 5 |
| airer service has no status property | 31 |

| The value-list descriptions of the status property in a airer service<br>(Remove the spaces, hyphens, and other punctuation marks in the phrases, and convert all letters to lowercase.) | Number |
|---|---|
|	down	|	108	|
|	stop	|	96	|
|	rising	|	85	|
|	pause	|	57	|
|	up	|	53	|
|	idle	|	36	|
|	busy	|	21	|
|	falling	|	19	|
|	settingheight	|	17	|
|	stopathighest	|	16	|
|	stopatlowest	|	16	|
|	stopatmiddle	|	14	|
|	lower	|	10	|
|	stopupperlimit	|	7	|
|	stoplowerlimit	|	7	|
|	dowm	|	7	|
|	rise	|	6	|
|	stopped	|	5	|
|	upper	|	4	|
|	upperlimitstop	|	3	|
|	lowerlimitstop	|	3	|
|	calibrating	|	3	|
|	normal	|	2	|
|	dropping	|	2	|
|	ceiling	|	2	|
|	floor	|	2	|
|	inpreparation	|	1	|
|	fault	|	1	|
|	downing	|	1	|
|	uping	|	1	|
|	risefinish	|	1	|
|	downfinish	|	1	|
|	impede	|	1	|
|	motorlock	|	1	|
|	obstaclestop	|	1	|
|	upperlimit	|	1	|
|	lowerlimit	|	1	|
|	limitfault	|	1	|
|	overheatingpro	|	1	|
|	circuitfault	|	1	|
|	custom	|	1	|
|	other	|	1	|

# Changed
- Do not record the "stop" status for the cover entity.
- Record the "opening", "closing" and "closed" status that occur frequently.