### PR TITLE
fix: mdns discovered ip address

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_mdns.py
+++ b/custom_components/xiaomi_home/miot/miot_mdns.py
@@ -110,7 +110,6 @@ class MipsServiceData:
             version=IPVersion.V4Only)
         if not self.addresses:
             raise MipsServiceError('invalid addresses')
-        self.addresses.sort()
         if not service_info.port:
             raise MipsServiceError('invalid port')
         self.port = service_info.port
@@ -226,7 +225,7 @@ class MipsService:
             state_change: ServiceStateChange
     ) -> None:
         _LOGGER.debug(
-            'mips service state changed, %s, %s, %s',
+            'mdns discovery changed, %s, %s, %s',
             state_change, name, service_type)
 
         if state_change is ServiceStateChange.Removed:


### PR DESCRIPTION
# Why
zeroconf parsed_addresses returns a list of ip addresses in which the first address will always be the most recently added address of the given IP version. If the address list is sorted, the first address may not be the latest valid address. Thus, reconnecting to the central hub gateway fails with "[Errno 113] Host is unreachable".

# Fixed
- Keep the first element of the address list as the recently added address.