### PR TITLE
fix: cover status

### DIFF
--- a/custom_components/xiaomi_home/cover.py
+++ b/custom_components/xiaomi_home/cover.py
@@ -170,12 +170,13 @@ class Cover(MIoTServiceEntity, CoverEntity):
                         self._prop_status_opening.append(item.value)
                     elif item_name in {
                             'closing', 'close', 'down', 'dowm', 'falling',
-                            'dropping', 'downing', 'lower'
+                            'fallin', 'dropping', 'downing', 'lower'
                     }:
                         self._prop_status_closing.append(item.value)
                     elif item_name in {
-                            'stopatlowest', 'stoplowerlimit', 'lowerlimitstop',
-                            'floor', 'lowerlimit'
+                            'closed', 'closeover', 'stopatlowest',
+                            'stoplowerlimit', 'lowerlimitstop', 'floor',
+                            'lowerlimit'
                     }:
                         self._prop_status_closed.append(item.value)
                 self._prop_status = prop


### PR DESCRIPTION
# Why
#1235 refactored the cover status for the airer device. However, the motor controller, the window opener and the curtain are also converted to the cover entity. #1235 does not contain the status descriptions of these devices.

As of July 14, 2025, the statistical results are as follows.
## Motor controller
| Circumstance | Number |
|---|---|
| motor-controller service has only one status property | 10 |
| motor-controller  service has multiple status properties | 0 |
| motor-controller  service has no status property | 14 |

| The value-list descriptions of the status property in a motor-controller service<br>(Remove the spaces, hyphens, and other punctuation marks in the phrases, <br>and convert all letters to lowercase.) | Number |
|---|---|
|	closing	|	5	|
|	opening	|	5	|
|	idle	|	4	|
|	busy	|	4	|
|	stop	|	2	|
|	open	|	2	|
|	pause	|	2	|
|	initialize	|	1	|
|	unlock	|	1	|
|	lock	|	1	|
|	fault	|	1	|
|	ideal	|	1	|
|	unknown	|	1	|
|	opened	|	1	|
|	closed	|	1	|
|	stopped	|	1	|
|	blockedbounce	|	1	|
|	overtimestopped	|	1	|
|	close	|	1	|

## Window opener
| Circumstance | Number |
|---|---|
| window-opener service has only one status property | 16 |
| window-opener  service has multiple status properties | 0 |
| window-opener service has no status property | 16 |

| The value-list descriptions of the status property in a window-opener service<br>(Remove the spaces, hyphens, and other punctuation marks in the phrases, <br>and convert all letters to lowercase.) | Number |
|---|---|
|	open	|	9	|
|	close	|	9	|
|	idle	|	7	|
|	pause	|	6	|
|	busy	|	5	|
|	stop	|	3	|
|	openover	|	2	|
|	closeover	|	2	|
|	opening	|	2	|
|	closing	|	2	|
|	fallin	|	1	|
|	delay	|	1	|
|	inward	|	1	|
|	otherpause	|	1	|

## Curtain
| Circumstance | Number |
|---|---|
| curtain service has only one status property | 245 |
| curtain  service has multiple status properties | 0 |
| curtain service has no status property | 359 |

| The value-list descriptions of the status property in a curtain service<br>(Remove the spaces, hyphens, and other punctuation marks in the phrases, <br>and convert all letters to lowercase.) | Number |
|---|---|
|	opening	|	174	|
|	closing	|	174	|
|	stop	|	166	|
|	idle	|	61	|
|	busy	|	57	|
|	pause	|	14	|
|	close	|	7	|
|	open	|	7	|
|	calibration	|	5	|
|	obstaclestop	|	4	|
|	1	|	2	|
|	2	|	2	|
|	0	|	2	|
|	3	|	2	|
|	offline	|	2	|
|	delay	|	2	|
|	declining	|	1	|
|	rising	|	1	|
|	blocked	|	1	|
|	on	|	1	|
|	off	|	1	|
|	steppingup	|	1	|
|	steppingdown	|	1	|
|	online	|	1	|
|	left	|	1	|
|	right	|	1	|
|	calibrate	|	1	|
|	calibrate2	|	1	|
|	calibratefail	|	1	|
|	lefting	|	1	|
|	righting	|	1	|
|	correcting	|	1	|

# Fixed
- Record the "closing" and "closed" status that occur frequently in the motor-controller, the window-opener and the curtain service.