### PR TITLE
feat: do not subscribe BLE device online/offline state message

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_mips.py
+++ b/custom_components/xiaomi_home/miot/miot_mips.py
@@ -994,6 +994,11 @@ class MipsCloudClient(_MipsClient):
                 handler(
                     did, MIoTDeviceState.ONLINE if msg['event'] == 'online'
                     else MIoTDeviceState.OFFLINE, ctx)
+
+        if did.startswith('blt.'):
+        # MIoT cloud may not publish BLE device online/offline state message.
+        # Do not subscribe BLE device online/offline state.
+            return True
         return self.__reg_broadcast_external(
             topic=topic, handler=on_state_msg, handler_ctx=handler_ctx)
 


### PR DESCRIPTION
# Why
In the issue #1251, MIoT cloud published an offline state message when the device became offline, but did not publish an online state message when the device became online. So, even xiaomi_home got properties_changed and event_occured message, the device entities was still shown unavailable.
MIoT cloud can not accurately determine the BLE device's online/offline state. Also see #1207. 

# Changed
- Do not subscribe BLE device online/offline state message. Assume that all BLE devices are online.