### PR TITLE
fix: ignore mdns REMOVED package

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_client.py
+++ b/custom_components/xiaomi_home/miot/miot_client.py
@@ -1037,11 +1037,11 @@ class MIoTClient:
 
         mips = self._mips_local.get(group_id, None)
         if mips:
-            if state == MipsServiceState.REMOVED:
-                mips.disconnect()
-                self._mips_local.pop(group_id, None)
-                return
-            if (
+            # if state == MipsServiceState.REMOVED:
+            #     mips.disconnect()
+            #     self._mips_local.pop(group_id, None)
+            #     return
+            if ( # ADDED or UPDATED
                 mips.client_id == self._entry_data['virtual_did']
                 and mips.host == data['addresses'][0]
                 and mips.port == data['port']

--- a/custom_components/xiaomi_home/miot/miot_mdns.py
+++ b/custom_components/xiaomi_home/miot/miot_mdns.py
@@ -232,9 +232,10 @@ class MipsService:
             for item in list(self._services.values()):
                 if item['name'] != name:
                     continue
-                service_data = self._services.pop(item['group_id'], {})
-                self.__call_service_change(
-                    state=MipsServiceState.REMOVED, data=service_data)
+            # Ignore mdns REMOVED package. Let the connection close by itself.
+                # service_data = self._services.pop(item['group_id'], {})
+                # self.__call_service_change(
+                #     state=MipsServiceState.REMOVED, data=service_data)
                 return
         self._main_loop.create_task(
             self.__request_service_info_async(zeroconf, service_type, name))


### PR DESCRIPTION
# Why
In issue [#1234](https://github.com/XiaoMi/ha_xiaomi_home/issues/1234#issuecomment-3100196800), xiaomi_home disconnected from the central hub gateway after it received a mdns REMOVED package. xiaomi_home reconnected the gateway when it received a mdns ADDED package again. However, the time between receiving a REMOVED package and a ADDED package ranges from several minutes to hours.
The user's MiHome APP showed that the central hub gateway was always online. The problem may be caused by the compatibility of the central hub gateway with the router.

# Changed
- Ignore the mdns REMOVED package. Let the connection to the central hub gateway close by itself. 