### PR TITLE
fix: set the device on when the switch status is False or None 

### DIFF
--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -546,7 +546,7 @@ class AirConditioner(FeatureOnOff, FeatureTargetTemperature,
                                    f'{self.entity_id}')
             return
         # set the device on
-        if self.get_prop_value(prop=self._prop_on) is False:
+        if self.get_prop_value(prop=self._prop_on) is not True:
             await self.set_property_async(prop=self._prop_on,
                                           value=True,
                                           write_ha_state=False)

--- a/custom_components/xiaomi_home/miot/specs/spec_add.json
+++ b/custom_components/xiaomi_home/miot/specs/spec_add.json
@@ -1,6 +1,24 @@
 {
   "urn:miot-spec-v2:device:air-conditioner:0000A004:090615-ktf:1": [
     {
+      "iid": 2,
+      "type": "urn:miot-spec-v2:service:switch:0000780C:090615-ktf:1",
+      "description": "AC Switch",
+      "properties": [
+        {
+          "iid": 1,
+          "type": "urn:miot-spec-v2:property:on:00000006:090615-ktf:1",
+          "description": "Switch Status",
+          "format": "bool",
+          "access": [
+            "read",
+            "write",
+            "notify"
+          ]
+        }
+      ]
+    },
+    {
       "iid": 4,
       "type": "urn:miot-spec-v2:service:environment:0000780A:090615-ktf:1",
       "description": "Environment",

--- a/custom_components/xiaomi_home/water_heater.py
+++ b/custom_components/xiaomi_home/water_heater.py
@@ -168,7 +168,7 @@ class WaterHeater(MIoTServiceEntity, WaterHeaterEntity):
         if operation_mode == STATE_ON:
             await self.set_property_async(prop=self._prop_on, value=True)
             return
-        if self.get_prop_value(prop=self._prop_on) is False:
+        if self.get_prop_value(prop=self._prop_on) is not True:
             await self.set_property_async(prop=self._prop_on,
                                           value=True,
                                           write_ha_state=False)


### PR DESCRIPTION
# Why
`get_prop_value` return None when it fails to get the property value. So the condition of setting the switch status to be True shall be "the switch status is not True".
090615.aircondition.ktf may not have the ability of handling multiple command messages in a short interval. A standalone switch entity can help users to turn on the device if the device does not turn on successfully after setting the HVAC mode.

# Changed
- Add a standalone switch entity for 090615.aircondition.ktf.

# Fixed
- Set the air conditioner and the water heater on when the switch status is False or None.