### PR TITLE
fix: correct the property value format after expression calculation

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -1108,6 +1108,8 @@ class MIoTServiceEntity(Entity):
             ):
                 continue
             value: Any = prop.value_format(params['value'])
+            value = prop.eval_expr(value)
+            value = prop.value_format(value)
             self._prop_value_map[prop] = value
             if prop in self._prop_changed_subs:
                 self._prop_changed_subs[prop](prop, value)
@@ -1279,8 +1281,9 @@ class MIoTPropertyEntity(Entity):
 
     def __on_value_changed(self, params: dict, ctx: Any) -> None:
         _LOGGER.debug('property changed, %s', params)
-        self._value = self.spec.value_format(params['value'])
-        self._value = self.spec.eval_expr(self._value)
+        value: Any = self.spec.value_format(params['value'])
+        value = self.spec.eval_expr(value)
+        self._value = self.spec.value_format(value)
         if not self._pending_write_ha_state_timer:
             self.async_write_ha_state()
 


### PR DESCRIPTION
# Why
The property value may be inconformable to the value-range step or the format after expression calculation. 

# Fixed
- Correct the property value format after expression calculation.
- Make expression calculation take effect for the property in  MIoTServiceEntity.