### PR TITLE
fix: contact-state value format

### DIFF
--- a/custom_components/xiaomi_home/binary_sensor.py
+++ b/custom_components/xiaomi_home/binary_sensor.py
@@ -70,8 +70,8 @@ async def async_setup_entry(
     for miot_device in device_list:
         if miot_device.miot_client.display_binary_bool:
             for prop in miot_device.prop_list.get('binary_sensor', []):
-                new_entities.append(BinarySensor(
-                    miot_device=miot_device, spec=prop))
+                new_entities.append(
+                    BinarySensor(miot_device=miot_device, spec=prop))
 
     if new_entities:
         async_add_entities(new_entities)
@@ -90,7 +90,7 @@ class BinarySensor(MIoTPropertyEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """On/Off state. True if the binary sensor is on, False otherwise."""
         if self.spec.name == 'contact-state':
-            return self._value is False
+            return bool(self._value) is False
         elif self.spec.name == 'occupancy-status':
             return bool(self._value)
         return self._value is True


### PR DESCRIPTION
# Why
The contact-state property of linp.magnet.m1 is modified by [spec_modify.yaml](https://github.com/XiaoMi/ha_xiaomi_home/blob/main/custom_components/xiaomi_home/miot/specs/spec_modify.yaml#L218), while its value format is not changed and is still int. The int value 0 or 1 is always not False.

# Fixed
- Convert the contact-state property value format to bool.