### PR TITLE
fix: integer value step

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -601,7 +601,10 @@ class MIoTSpecProperty(_MIoTSpecBase):
         if value is None:
             return None
         if self.format_ == int:
-            return int(round(value))
+            if self.value_range is None:
+                return int(round(value))
+            return int(
+                round(value / self.value_range.step) * self.value_range.step)
         if self.format_ == float:
             return round(value, self.precision)
         if self.format_ == bool:


### PR DESCRIPTION
# Why
The integer property value must comply with the value step defined in the value-range field, otherwise the device will response error when setting the property with a wrong value.

# Fixed
- Correct the integer value to comply with the value step.