### PR TITLE
feat: remove VacuumEntityFeature.BATTERY from the vacuum entity

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -167,11 +167,6 @@ SPEC_DEVICE_TRANS_MAP: dict = {
             },
             'battery': {
                 'required': {
-                    'properties': {
-                        'battery-level': {'read'}
-                    }
-                },
-                'optional': {
                     'actions': {
                         'start-charge'
                     }

--- a/custom_components/xiaomi_home/vacuum.py
+++ b/custom_components/xiaomi_home/vacuum.py
@@ -90,7 +90,6 @@ class Vacuum(MIoTServiceEntity, StateVacuumEntity):
     # pylint: disable=unused-argument
     _prop_status: Optional[MIoTSpecProperty]
     _prop_fan_level: Optional[MIoTSpecProperty]
-    _prop_battery_level: Optional[MIoTSpecProperty]
     _prop_status_cleaning: Optional[list[int]]
     _prop_status_docked: Optional[list[int]]
     _prop_status_paused: Optional[list[int]]
@@ -117,7 +116,6 @@ class Vacuum(MIoTServiceEntity, StateVacuumEntity):
 
         self._prop_status = None
         self._prop_fan_level = None
-        self._prop_battery_level = None
         self._prop_status_cleaning = []
         self._prop_status_docked = []
         self._prop_status_paused = []
@@ -180,9 +178,6 @@ class Vacuum(MIoTServiceEntity, StateVacuumEntity):
                 self._attr_fan_speed_list = list(self._fan_level_map.values())
                 self._attr_supported_features |= VacuumEntityFeature.FAN_SPEED
                 self._prop_fan_level = prop
-            elif prop.name == 'battery-level':
-                self._attr_supported_features |= VacuumEntityFeature.BATTERY
-                self._prop_battery_level = prop
         # action
         for action in entity_data.actions:
             if action.name == 'start-sweep':
@@ -250,11 +245,6 @@ class Vacuum(MIoTServiceEntity, StateVacuumEntity):
     def name(self) -> Optional[str]:
         """Name of the vacuum entity."""
         return self._device_name
-
-    @property
-    def battery_level(self) -> Optional[int]:
-        """The current battery level of the vacuum cleaner."""
-        return self.get_prop_value(prop=self._prop_battery_level)
 
     @property
     def fan_speed(self) -> Optional[str]:


### PR DESCRIPTION
# Why
To solve #1414 .
[battery_level propery have been deprecated since Home Assistant Core 2025.8 and will stop working from 2026.8.](https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated/)

# Changed
- Remove VacuumEntityFeature.BATTERY and affiliated `battery_level` property from the vacuum entity. The battery level of a vacuum is converted to a sensor entity.