### PR TITLE
fix: pylint 4.0.0

### DIFF
--- a/custom_components/xiaomi_home/miot/web_pages.py
+++ b/custom_components/xiaomi_home/miot/web_pages.py
@@ -49,7 +49,7 @@ MIoT redirect web pages.
 import os
 import asyncio
 
-_template = ''
+web_template = ''
 
 
 def _load_page_template():
@@ -57,18 +57,18 @@ def _load_page_template():
         os.path.dirname(os.path.abspath(__file__)),
         'resource/oauth_redirect_page.html')
     with open(path, 'r', encoding='utf-8') as f:
-        global _template
-        _template = f.read()
+        global web_template
+        web_template = f.read()
 
 
 async def oauth_redirect_page(
     title: str, content: str, button: str, success: bool
 ) -> str:
     """Return oauth redirect page."""
-    if _template == '':
+    if web_template == '':
         await asyncio.get_running_loop().run_in_executor(
             None, _load_page_template)
-    web_page = _template.replace('TITLE_PLACEHOLDER', title)
+    web_page = web_template.replace('TITLE_PLACEHOLDER', title)
     web_page = web_page.replace('CONTENT_PLACEHOLDER', content)
     web_page = web_page.replace('BUTTON_PLACEHOLDER', button)
     web_page = web_page.replace(


### PR DESCRIPTION
To fix the error reported by the latest pylint-4.0.0: 
xiaomi_home/miot/web_pages.py:52:0: C0103: Variable name "\_template" doesn't conform to '^[a-z][a-z0-9_]*$' pattern (invalid-name)