### PR TITLE
fix: float value precision 

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -66,7 +66,7 @@ class MIoTSpecValueRange:
     """MIoT SPEC value range class."""
     min_: int
     max_: int
-    step: int
+    step: int | float
 
     def __init__(self, value_range: Union[dict, list]) -> None:
         if isinstance(value_range, dict):
@@ -567,9 +567,8 @@ class MIoTSpecProperty(_MIoTSpecBase):
             return
         self._value_range = MIoTSpecValueRange(value_range=value)
         if isinstance(value, list):
-            self.precision = len(str(
-                value[2]).split('.')[1].rstrip('0')) if '.' in str(
-                    value[2]) else 0
+            step_: str = format(value[2], '.10f').rstrip('0').rstrip('.')
+            self.precision = len(step_.split('.')[1]) if '.' in step_ else 0
 
     @property
     def value_list(self) -> Optional[MIoTSpecValueList]:


### PR DESCRIPTION
# Why
If the value step of a float value is less than 0.0001, it is stored in scientific notation. For example, 0.000001 is stored as 1e-06, thus the value precision is wrongly calculated to be 0.

# Fixed
- Convert the number displayed in scientific notation into a regular decimal before counting the number of digits after the decimal point.