### PR TITLE
fix: climate entity swing mode setting

### DIFF
--- a/custom_components/xiaomi_home/climate.py
+++ b/custom_components/xiaomi_home/climate.py
@@ -320,17 +320,17 @@ class FeatureSwingMode(MIoTServiceEntity, ClimateEntity):
             await self.set_property_async(prop=self._prop_vertical_swing,
                                           value=True)
         elif swing_mode == SWING_HORIZONTAL:
-            await self.set_property_async(prop=self._prop_horizontal_swing,
-                                          value=True)
             if self._prop_vertical_swing:
                 await self.set_property_async(prop=self._prop_vertical_swing,
                                               value=False)
-        elif swing_mode == SWING_VERTICAL:
-            await self.set_property_async(prop=self._prop_vertical_swing,
+            await self.set_property_async(prop=self._prop_horizontal_swing,
                                           value=True)
+        elif swing_mode == SWING_VERTICAL:
             if self._prop_horizontal_swing:
                 await self.set_property_async(prop=self._prop_horizontal_swing,
                                               value=False)
+            await self.set_property_async(prop=self._prop_vertical_swing,
+                                          value=True)
         elif swing_mode == SWING_OFF:
             if self._prop_horizontal_swing:
                 await self.set_property_async(prop=self._prop_horizontal_swing,


### PR DESCRIPTION
# Why
To solve [#1386](https://github.com/XiaoMi/ha_xiaomi_home/issues/1386#issuecomment-3400447899).
The climate entity's swing mode is determined by two MIoT-Spec-V2 properties that are the horizontal-swing property and the vertical-swing property. When either vertical swing or horizontal swing is activated alone, the other swing mode should be turned off.

# Fixed
- Turn off the other swing mode when setting vertical swing or horizontal swing alone.