### PR TITLE
fix: xiaomi.derh.lite temperature precision

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
+++ b/custom_components/xiaomi_home/miot/specs/spec_modify.yaml
@@ -92,12 +92,6 @@ urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-ua1a:2: urn:miot-spec-v2:dev
 urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-ua1a:3:
   prop.3.5:
     expr: (src_value*6)
-urn:miot-spec-v2:device:dehumidifier:0000A02D:xiaomi-lite:1:
-  prop.3.2:
-    value-range:
-    - -30
-    - 100
-    - 0.1
 urn:miot-spec-v2:device:airer:0000A00D:hyd-lyjpro:1:
   prop.2.3:
     name: current-position-a
@@ -144,6 +138,12 @@ urn:miot-spec-v2:device:bath-heater:0000A028:xiaomi-s1:1:
 urn:miot-spec-v2:device:curtain:0000A00C:bjkcz-kczble:1:0000D031:
   prop.2.2:
     name: status-a
+urn:miot-spec-v2:device:dehumidifier:0000A02D:xiaomi-lite:1:
+  prop.3.2:
+    value-range:
+    - -30
+    - 100
+    - 0.1
 urn:miot-spec-v2:device:electronic-valve:0000A0A7:sanmei-s1:1:
   prop.3.1:
     format: float


### PR DESCRIPTION
Add value-range step of 0.1 for dehumidifier temperature property to preserve decimal precision.

The xiaomi.derh.lite dehumidifier was reporting temperature as integer instead of float due to the default value-range step of 1. This fix changes the step to 0.1 to allow one decimal place precision (e.g., 22.5°C instead of 23°C).

Similar to the fix for cgllc.airm.cgd1st air monitor in commit 580ff87.