### PR TITLE
fix: value step

### DIFF
--- a/custom_components/xiaomi_home/miot/miot_spec.py
+++ b/custom_components/xiaomi_home/miot/miot_spec.py
@@ -617,7 +617,8 @@ class MIoTSpecProperty(_MIoTSpecBase):
             if self.value_range is None:
                 return int(round(value))
             return int(
-                round(value / self.value_range.step) * self.value_range.step)
+                round((value - self.value_range.min_) / self.value_range.step) *
+                self.value_range.step + self.value_range.min_)
         return value
 
     def dump(self) -> dict:


### PR DESCRIPTION
# Why
In the issue #1613, [mipin9.curtain.mpcldj](http://poc.miot-spec.srv/miot-spec-v2/instance?type=urn:miot-spec-v2:device:curtain:0000A00C:mipin9-mpcldj:1:0000C817) siid=5 piid=4 light color-temperature property's value range is [2700, 6500, 38]. The minimum value is not 0, so the former calculation method gets the wrong value.

# Fixed
- Calculate the property value for the right value step.