### PR TITLE
fix: add state_class for co2-density sensor

### DIFF
--- a/custom_components/xiaomi_home/miot/specs/specv2entity.py
+++ b/custom_components/xiaomi_home/miot/specs/specv2entity.py
@@ -51,6 +51,7 @@ from homeassistant.components.event import EventDeviceClass
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
 from homeassistant.const import (CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                                 CONCENTRATION_PARTS_PER_MILLION,
                                  EntityCategory, LIGHT_LUX, UnitOfEnergy,
                                  UnitOfPower, UnitOfElectricCurrent,
                                  UnitOfElectricPotential, UnitOfTemperature,
@@ -641,6 +642,12 @@ SPEC_PROP_TRANS_MAP: dict = {
             'device_class': SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
             'entity': 'sensor',
             'state_class': SensorStateClass.MEASUREMENT
+        },
+        'co2-density': {
+            'device_class': SensorDeviceClass.CO2,
+            'entity': 'sensor',
+            'state_class': SensorStateClass.MEASUREMENT,
+            'unit_of_measurement': CONCENTRATION_PARTS_PER_MILLION
         },
         'battery-level': {
             'device_class': SensorDeviceClass.BATTERY,


### PR DESCRIPTION
## Summary

Add `co2-density` property mapping to `SPEC_PROP_TRANS_MAP` to enable statistics recording for CO2 sensors.

## Changes

- Import `CONCENTRATION_PARTS_PER_MILLION` from `homeassistant.const`
- Add `co2-density` mapping with:
  - `device_class`: `SensorDeviceClass.CO2`
  - `state_class`: `SensorStateClass.MEASUREMENT`
  - `unit_of_measurement`: `CONCENTRATION_PARTS_PER_MILLION` (ppm)

## Why

Currently, CO2 sensors (like those from CGDN1/Qingping Air Monitor Lite device) are missing:
- `state_class` attribute
- `device_class` attribute
- proper unit of measurement

This prevents Home Assistant from recording long-term statistics for CO2 sensors, while other similar density sensors (PM2.5, PM10, TVOC, VOC) work correctly.

## Testing

After applying this fix, CO2 sensor entity shows:
```json
{
  "state_class": "measurement",
  "device_class": "carbon_dioxide",
  "unit_of_measurement": "ppm"
}
```

Home Assistant statistics recording is now enabled for CO2 sensors.


<img width="884" height="761" alt="image" src="https://github.com/user-attachments/assets/aa0964d2-6a2c-45af-a95f-5cef0997cd4d" />



Fixes #1630