### PR TITLE
compat: recover the entries updated by this patch

### DIFF
--- a/custom_components/xiaomi_home/__init__.py
+++ b/custom_components/xiaomi_home/__init__.py
@@ -359,12 +359,15 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         config_entry.minor_version,
     )
 
-    if config_entry.version > 1:
+    if config_entry.version > 2:
         # This means the user has downgraded from a future version
         return False
 
     if config_entry.version == 1:
         await _migrate_v1_to_v2(hass, config_entry)
+
+    if config_entry.version == 2:
+        await _migrate_v2_to_v3(hass, config_entry)
 
     _LOGGER.debug(
         'Migration to configuration version %s.%s successful',
@@ -439,7 +442,7 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
                 )
                 if entity_id is None:
                     continue
-                new_unique_id = device.gen_service_entity_id(
+                new_unique_id = device.gen_service_entity_id_v2(
                     ha_domain=DOMAIN,
                     siid=entity.spec.iid,
                     description=entity.spec.description,
@@ -447,3 +450,80 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
                 er.async_update_entity(entity_id, new_unique_id=new_unique_id)
 
     hass.config_entries.async_update_entry(config_entry, version=2)
+
+
+async def _migrate_v2_to_v3(hass: HomeAssistant, config_entry: ConfigEntry):
+    def ha_persistent_notify(
+        notify_id: str, title: Optional[str] = None,
+        message: Optional[str] = None
+    ) -> None:
+        """Send messages in Notifications dialog box."""
+        if title:
+            persistent_notification.async_create(
+                hass=hass,  message=message or '',
+                title=title, notification_id=notify_id)
+        else:
+            persistent_notification.async_dismiss(
+                hass=hass, notification_id=notify_id)
+
+    entry_id = config_entry.entry_id
+    entry_data = dict(config_entry.data)
+
+    ha_persistent_notify(
+        notify_id=f'{entry_id}.oauth_error', title=None, message=None)
+
+    miot_client: MIoTClient = await get_miot_instance_async(
+        hass=hass, entry_id=entry_id,
+        entry_data=entry_data,
+        persistent_notify=ha_persistent_notify)
+    # Spec parser
+    spec_parser = MIoTSpecParser(
+        lang=entry_data.get(
+            'integration_language', DEFAULT_INTEGRATION_LANGUAGE),
+        storage=miot_client.miot_storage,
+        loop=miot_client.main_loop
+    )
+    await spec_parser.init_async()
+    # Manufacturer
+    manufacturer: DeviceManufacturer = DeviceManufacturer(
+        storage=miot_client.miot_storage,
+        loop=miot_client.main_loop)
+    await manufacturer.init_async()
+    er = entity_registry.async_get(hass)
+    for _, info in miot_client.device_list.items():
+        spec_instance = await spec_parser.parse(urn=info['urn'])
+        if not isinstance(spec_instance, MIoTSpecInstance):
+            continue
+        device: MIoTDevice = MIoTDevice(
+            miot_client=miot_client,
+            device_info={
+                **info, 'manufacturer': manufacturer.get_name(
+                    info.get('manufacturer', ''))},
+            spec_instance=spec_instance)
+        device.spec_transform()
+
+        # Update unique_id
+        for platform, entities in device.entity_list.items():
+            for entity in entities:
+                if not isinstance(entity.spec, MIoTSpecService):
+                    continue
+                old_unique_id = device.gen_service_entity_id_v2(
+                    ha_domain=DOMAIN,
+                    siid=entity.spec.iid,
+                    description=entity.spec.description,
+                )
+                entity_id = er.async_get_entity_id(
+                    platform, DOMAIN, old_unique_id
+                )
+                if entity_id is None:
+                    continue
+                new_unique_id = device.gen_service_entity_id(
+                    ha_domain=DOMAIN,
+                    siid=entity.spec.iid,
+                    description=entity.spec.description,
+                )
+                if new_unique_id == old_unique_id:
+                    continue
+                er.async_update_entity(entity_id, new_unique_id=new_unique_id)
+
+    hass.config_entries.async_update_entry(config_entry, version=3)

--- a/custom_components/xiaomi_home/__init__.py
+++ b/custom_components/xiaomi_home/__init__.py
@@ -354,7 +354,7 @@ async def async_remove_config_entry_device(
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Migrate old entry."""
     _LOGGER.debug(
-        "Migrating configuration from version %s.%s",
+        'Migrating configuration from version %s.%s',
         config_entry.version,
         config_entry.minor_version,
     )
@@ -367,7 +367,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):
         await _migrate_v1_to_v2(hass, config_entry)
 
     _LOGGER.debug(
-        "Migration to configuration version %s.%s successful",
+        'Migration to configuration version %s.%s successful',
         config_entry.version,
         config_entry.minor_version,
     )
@@ -413,8 +413,8 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
         loop=miot_client.main_loop)
     await manufacturer.init_async()
     er = entity_registry.async_get(hass)
-    for did, info in miot_client.device_list.items():
-        spec_instance = await spec_parser.parse(urn=info["urn"])
+    for _, info in miot_client.device_list.items():
+        spec_instance = await spec_parser.parse(urn=info['urn'])
         if not isinstance(spec_instance, MIoTSpecInstance):
             continue
         device: MIoTDevice = MIoTDevice(
@@ -426,15 +426,17 @@ async def _migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
         device.spec_transform()
 
         # Update unique_id
-        for platform in device.entity_list:
-            for entity in device.entity_list[platform]:
+        for platform, entities in device.entity_list.items():
+            for entity in entities:
                 if not isinstance(entity.spec, MIoTSpecService):
                     continue
                 old_unique_id = device.gen_service_entity_id_v1(
                     ha_domain=DOMAIN,
                     siid=entity.spec.iid,
                 )
-                entity_id = er.async_get_entity_id(platform, DOMAIN, old_unique_id)
+                entity_id = er.async_get_entity_id(
+                    platform, DOMAIN, old_unique_id
+                )
                 if entity_id is None:
                     continue
                 new_unique_id = device.gen_service_entity_id(

--- a/custom_components/xiaomi_home/config_flow.py
+++ b/custom_components/xiaomi_home/config_flow.py
@@ -109,7 +109,7 @@ _LOGGER = logging.getLogger(__name__)
 class XiaomiMihomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Xiaomi Home config flow."""
     # pylint: disable=unused-argument, inconsistent-quotes
-    VERSION = 2
+    VERSION = 3
     MINOR_VERSION = 1
     DEFAULT_AREA_NAME_RULE = 'room'
     _main_loop: asyncio.AbstractEventLoop

--- a/custom_components/xiaomi_home/config_flow.py
+++ b/custom_components/xiaomi_home/config_flow.py
@@ -105,7 +105,7 @@ _LOGGER = logging.getLogger(__name__)
 class XiaomiMihomeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Xiaomi Home config flow."""
     # pylint: disable=unused-argument, inconsistent-quotes
-    VERSION = 1
+    VERSION = 2
     MINOR_VERSION = 1
     DEFAULT_AREA_NAME_RULE = 'room'
     _main_loop: asyncio.AbstractEventLoop

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -353,11 +353,17 @@ class MIoTDevice:
             f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
             f'{self._model_strs[-1][:20]}_s_{siid}')
 
-    def gen_service_entity_id(self, ha_domain: str, siid: int,
+    def gen_service_entity_id_v2(self, ha_domain: str, siid: int,
                               description: str) -> str:
         return (
             f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
             f'{self._model_strs[-1][:20]}_s_{siid}_{description}')
+
+    def gen_service_entity_id(self, ha_domain: str, siid: int,
+                              description: str) -> str:
+        return (
+            f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
+            f'{self._model_strs[-1][:20]}_s_{siid}_{slugify_name(description)}')
 
     def gen_prop_entity_id(
         self, ha_domain: str, spec_name: str, siid: int, piid: int

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -361,9 +361,11 @@ class MIoTDevice:
 
     def gen_service_entity_id(self, ha_domain: str, siid: int,
                               description: str) -> str:
+        slug = slugify_name(description)
+        description_suffix = f'_{slug}' if slug else ''
         return (
             f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
-            f'{self._model_strs[-1][:20]}_s_{siid}_{slugify_name(description)}')
+            f'{self._model_strs[-1][:20]}_s_{siid}{description_suffix}')
 
     def gen_prop_entity_id(
         self, ha_domain: str, spec_name: str, siid: int, piid: int

--- a/custom_components/xiaomi_home/miot/miot_device.py
+++ b/custom_components/xiaomi_home/miot/miot_device.py
@@ -345,6 +345,11 @@ class MIoTDevice:
             f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
             f'{self._model_strs[-1][:20]}')
 
+    def gen_service_entity_id_v1(self, ha_domain: str, siid: int) -> str:
+        return (
+            f'{ha_domain}.{self._model_strs[0][:9]}_{self.did_tag}_'
+            f'{self._model_strs[-1][:20]}_s_{siid}')
+
     def gen_service_entity_id(self, ha_domain: str, siid: int,
                               description: str) -> str:
         return (


### PR DESCRIPTION
# 更新 2026-08-20：本 PR 转为过渡分支

主线修复拆成了两个独立 PR：#1777（修 entity_id 弃用警告）和 #1778（迁移 unique_id），都不再改 config entry 版本号。本 PR 不再谋求合入主线，只留给已经拉过它的人做过渡，收尾 commit 会把版本号复位回 1、把 unique_id 改回主线格式。

之前拉过本分支的用户：重新拉取本分支（经过 force-push），重启 Home Assistant 一次。就这样，无需其它操作，下面的旧说明全部作废。完成之后继续用本分支或切回主线都可以。

---

（以下为原始内容，已过时）

# Update

HA 2026.2.1 已修复此问题，将限制放宽到 2027.2.0

此 PR 仍有价值，这里提供了一种迁移到合法 unique_id 的方案。

The current warning:
> `Detected that custom integration 'xiaomi_home' sets an invalid entity ID: 'xiaomi_home.yeelink_cn_*********_lamp15_s_2_'. In most cases, entities should not set entity_id, but if they do, it should be a valid entity ID.. This will stop working in Home Assistant 2027.2.0`


---

# Why

更新到 HA 2026.2.0 之后，由于 Invalid entity ID 会导致部分实体不可用。

# Fixed

这个 PR 是给那些有着大量设备、大量界面配置和自动化的用户用的。
如果只是简单更换 unique_id 的方式修，而不提供迁移步骤，会导致大量旧的配置不可用。就和之前 #972 那样。

由于目前官方还没有出解决方案，这里先简单使用 `slugify_name` 来处理不合法的 unique_id。

**这个 PR 也包含了 #972 的代码**，使用了一样的方式来实现 unique_id 的修改，
不管是 v1 还是 v2 的用户都可以直接使用，**使用之后版本号会变成 3**。

#1627
#1632 
#1634 
#1635 
#1636 
#1638 

# Usage

1. 拉取这个PR的代码， 重启HA
3. 然后应该就好了，和原来一样。（不过版本号会变成3）

# Caution

版本号变了之后就不能直接切回主线了，（但现在主线还没修，本来就也没法切回去）


